### PR TITLE
Some status are published as 0 / 1 not boolean

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -229,7 +229,8 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
             _sensor = {}
             try:
                 sensor_property = BINARY_SENSORS[binary_sensor].key
-                _sensor[binary_sensor] = getattr(self._manager, sensor_property)
+                # Data can be sent as boolean or as 1/0
+                _sensor[binary_sensor] = bool(getattr(self._manager, sensor_property))
                 _LOGGER.debug(
                     "binary sensor: %s sensor_property: %s value %s",
                     binary_sensor,


### PR DESCRIPTION
Minor fix to correctly retrieve the binary sensors as some data is published as 0 / 1 instead of boolean