### PR TITLE
fix: remove `_` from default sensor names

### DIFF
--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -49,7 +49,7 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
         self._state = None
         self._icon = sensor_description.icon
 
-        self._attr_name = f"{self._config.data[CONF_NAME]}_{self._name}"
+        self._attr_name = f"{self._config.data[CONF_NAME]} {self._name}"
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
 
     @property


### PR DESCRIPTION
Fixes #58 