### PR TITLE
fix: typo in firmware sensor name

### DIFF
--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -111,6 +111,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         name="Protocol Version",
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     "charging_voltage": SensorEntityDescription(
         key="charging_voltage",
@@ -160,7 +161,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     ),
     "wifi_firmware": SensorEntityDescription(
         key="wifi_firmware",
-        name="Wifi Fimrware Version",
+        name="WiFi Firmware Version",
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -174,7 +175,7 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
     ),
     "wifi_signal": SensorEntityDescription(
         key="wifi_signal",
-        name="Wifi Signal Strength",
+        name="WiFi Signal Strength",
         icon="mdi:wifi",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -80,7 +80,7 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
             ]:
                 self._state = round(data[self._type] / 1000, 2)
             elif self._type == "charging_voltage":
-                self._state = round(data[self._type],0)
+                self._state = round(data[self._type], 0)
             else:
                 self._state = data[self._type]
 
@@ -96,6 +96,8 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Return if entity is available."""
+        if self._type not in self.coordinator.data:
+            return False
         return self.coordinator.last_update_success
 
     @property


### PR DESCRIPTION
* fix typo in firmware sensor name
* change device info to show buildenv if available and set firmware version to wifi firmware version rather than the evse firmware
* if sensor data is unavailable mark it unavailable rather than 'unknown'
* rename `Wifi` to `WiFi` on applicable sensors

related to #83 