### PR TITLE
feat: add shaper support, vehicle soc/eta/range

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -22,6 +22,7 @@ from .const import (
     ISSUE_URL,
     MANAGER,
     PLATFORMS,
+    SELECT_TYPES,
     SENSOR_TYPES,
     VERSION,
 )
@@ -257,6 +258,24 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.info(
                     "Could not update status for %s",
                     binary_sensor,
+                )
+            data.update(_sensor)
+        for select in SELECT_TYPES:
+            _sensor = {}
+            try:
+                sensor_property = SELECT_TYPES[select].key
+                # Data can be sent as boolean or as 1/0
+                _sensor[select] = getattr(self._manager, sensor_property)
+                _LOGGER.debug(
+                    "select: %s sensor_property: %s value %s",
+                    select,
+                    sensor_property,
+                    _sensor[select],
+                )
+            except (ValueError, KeyError):
+                _LOGGER.info(
+                    "Could not update status for %s",
+                    select,
                 )
             data.update(_sensor)
         _LOGGER.debug("DEBUG: %s", data)

--- a/custom_components/openevse/button.py
+++ b/custom_components/openevse/button.py
@@ -32,17 +32,20 @@ async def async_setup_entry(
 
     buttons = []
     for button in BUTTON_TYPES:
-        buttons.append(
-            OpenEVSEButton(BUTTON_TYPES[button], manager, config_entry)
-        )
+        buttons.append(OpenEVSEButton(BUTTON_TYPES[button], manager, config_entry))
 
-    async_add_entities(buttons, False)    
+    async_add_entities(buttons, False)
 
 
 class OpenEVSEButton(ButtonEntity):
     """OpenEVSE restart button."""
 
-    def __init__(self, button_description: ButtonEntityDescription, manager: OpenEVSEManager, config_entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        button_description: ButtonEntityDescription,
+        manager: OpenEVSEManager,
+        config_entry: ConfigEntry,
+    ) -> None:
         """Initialise a LIFX button."""
         self.entity_description = button_description
         self.config = config_entry

--- a/custom_components/openevse/button.py
+++ b/custom_components/openevse/button.py
@@ -46,7 +46,7 @@ class OpenEVSEButton(ButtonEntity):
         manager: OpenEVSEManager,
         config_entry: ConfigEntry,
     ) -> None:
-        """Initialise a LIFX button."""
+        """Initialise a OpenEVSE button."""
         self.entity_description = button_description
         self.config = config_entry
         self.manager = manager

--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -20,6 +20,8 @@ from homeassistant.const import (
     ELECTRIC_CURRENT_AMPERE,
     ELECTRIC_POTENTIAL_VOLT,
     ENERGY_KILO_WATT_HOUR,
+    LENGTH_METERS,
+    PERCENTAGE,
     POWER_WATT,
     SIGNAL_STRENGTH_DECIBELS,
     TEMP_CELSIUS,
@@ -222,6 +224,57 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
     ),
+    "shaper_live_power": SensorEntityDescription(
+        name="Shaper Power",
+        key="shaper_live_power",
+        icon="mdi:flash",
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        entity_registry_enabled_default=False,
+    ),
+    "shaper_current": SensorEntityDescription(
+        name="Shaper Current",
+        key="shaper_current_power",
+        icon="mdi:flash",
+        native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    "shaper_max_power": SensorEntityDescription(
+        name="Shaper Max Power",
+        key="shaper_max_power",
+        icon="mdi:flash",
+        native_unit_of_measurement=POWER_WATT,
+        device_class=SensorDeviceClass.POWER,
+        entity_registry_enabled_default=False,
+    ),
+    "vehicle_soc": SensorEntityDescription(
+        name="Vehicle Battery Level",
+        key="vehicle_soc",
+        icon="mdi:battery",
+        native_unit_of_measurement=PERCENTAGE,
+        device_class=SensorDeviceClass.BATTERY,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    "vehicle_range": SensorEntityDescription(
+        name="Vehicle Range",
+        key="vehicle_range",
+        icon="mdi:ev-station",
+        native_unit_of_measurement=LENGTH_METERS,
+        device_class=SensorDeviceClass.DISTANCE,
+        entity_registry_enabled_default=False,
+    ),
+    "vehicle_eta": SensorEntityDescription(
+        name="Vehicle Charge Completion",
+        key="vehicle_eta",
+        icon="mdi:car-electric",
+        native_unit_of_measurement=TIME_MINUTES,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
 }
 
 SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
@@ -248,9 +301,9 @@ SELECT_TYPES: Final[dict[str, OpenEVSESelectEntityDescription]] = {
         command="$SL",
         entity_category=EntityCategory.CONFIG,
     ),
-    "current_capacity": OpenEVSESelectEntityDescription(
+    "max_current_soft": OpenEVSESelectEntityDescription(
         name="Max Current",
-        key="current_capacity",
+        key="max_current_soft",
         default_options=None,
         command="set_current",
         entity_category=EntityCategory.CONFIG,
@@ -295,6 +348,11 @@ BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),
+    "shaper_active": BinarySensorEntityDescription(
+        name="Shaper Active",
+        key="shaper_active",
+        device_class=BinarySensorDeviceClass.POWER,
+    ),
 }
 
 BUTTON_TYPES: Final[dict[str, ButtonEntityDescription]] = {
@@ -302,12 +360,12 @@ BUTTON_TYPES: Final[dict[str, ButtonEntityDescription]] = {
         key="restart_wifi",
         name="Restart WiFi",
         device_class=ButtonDeviceClass.RESTART,
-        entity_category=EntityCategory.CONFIG,        
+        entity_category=EntityCategory.CONFIG,
     ),
     "restart_evse": ButtonEntityDescription(
         key="restart_evse",
         name="Restart EVSE",
         device_class=ButtonDeviceClass.RESTART,
-        entity_category=EntityCategory.CONFIG,        
-    ),    
+        entity_category=EntityCategory.CONFIG,
+    ),
 }

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -2,7 +2,7 @@
   "domain": "openevse",
   "name": "OpenEVSE",
   "documentation": "https://www.home-assistant.io/integrations/openevse",
-  "requirements": ["python-openevse-http==0.1.31"],
+  "requirements": ["python-openevse-http==0.1.34"],
   "zeroconf": ["_openevse._tcp.local."],
   "codeowners": [],
   "iot_class": "local_push",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.1.31
+python-openevse-http==0.1.34


### PR DESCRIPTION
* add shaper support
* use max_current_soft for current selector (defaults to pilot reading if max_current_soft isn't available)
* support vehicle SOC (state of charge/battery level), estimated time to recharge, and range if applicable
