### PR TITLE
feat: add `max_current` sensor

### DIFF
--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -347,6 +347,14 @@ SENSOR_TYPES: Final[dict[str, SensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_enabled_default=False,
     ),
+    "max_current": SensorEntityDescription(
+        key="max_current",
+        name="Max Current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),    
 }
 
 SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
@@ -388,7 +396,7 @@ SELECT_TYPES: Final[dict[str, OpenEVSESelectEntityDescription]] = {
     #     entity_category=EntityCategory.CONFIG,
     # ),
     "max_current_soft": OpenEVSESelectEntityDescription(
-        name="Max Current",
+        name="Charge Rate",
         key="current_capacity",
         default_options=None,
         command="set_current",

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/firstof9/openevse/issues",
   "loggers": ["openevsehttp"],
-  "requirements": ["python-openevse-http==0.1.61"],
+  "requirements": ["python-openevse-http==0.1.62"],
   "version": "0.0.0-dev",
   "zeroconf": ["_openevse._tcp.local."]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.1.60
+python-openevse-http==0.1.62

--- a/tests/fixtures/status.json
+++ b/tests/fixtures/status.json
@@ -16,7 +16,7 @@
     "evse_connected": 1,
     "amp": 32.2,
     "voltage": 240,
-    "pilot": 48,
+    "pilot": 40,
     "wh": 64582,
     "temp": 503,
     "temp1": false,
@@ -49,5 +49,6 @@
     "shaper_cur": 21,
     "vehicle_soc": 75,
     "vehicle_range": 468,
-    "vehicle_eta": 18000
+    "vehicle_eta": 18000,
+    "max_current": 48
   }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -31,7 +31,7 @@ async def test_setup_entry(hass, test_charger, mock_ws_start):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -51,7 +51,7 @@ async def test_setup_entry_bad_serial(hass, test_charger_bad_serial, mock_ws_sta
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -71,7 +71,7 @@ async def test_setup_and_unload_entry(hass, test_charger):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -102,7 +102,7 @@ async def test_setup_entry_state_change(hass, test_charger, mock_ws_start, caplo
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 22
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -132,7 +132,7 @@ async def test_setup_entry_state_change_timeout(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 22
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -162,7 +162,7 @@ async def test_setup_entry_state_change_2(hass, test_charger, mock_ws_start, cap
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 22
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -197,7 +197,7 @@ async def test_setup_entry_state_change_2_bad_post(
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 22
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -31,7 +31,7 @@ async def test_sensors(hass, test_charger, mock_ws_start):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 20
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 21
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -48,3 +48,6 @@ async def test_sensors(hass, test_charger, mock_ws_start):
     state = hass.states.get("sensor.openevse_total_usage")
     assert state
     assert state.state == "64.582"
+    state = hass.states.get("sensor.openevse_max_current")
+    assert state
+    assert state.state == "48"

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ python =
   3.11: py311
   3.12: py312, lint, mypy
 
+[pytest]
+asyncio_default_fixture_loop_scope=function
+
 [testenv]
 commands =
   pytest --asyncio-mode=auto --timeout=30 --cov=custom_components/openevse --cov-report=xml {posargs}


### PR DESCRIPTION
fixes #384 

Provides `max_current` sensor.
Change old "max current" selector to `Charge Rate` to better reflect it's use.