### PR TITLE
chore: add autolabeler and PR title linting

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,41 @@
 backend:
-  - custom_components/openevse/**/*.py
+  - changed-files:
+      - any-glob-to-any-file: custom_components/openevse/**/*.py
 tests:
-  - tests/**/*
+  - changed-files:
+      - any-glob-to-any-file: tests/**/*
 translations:
-  - custom_components/openevse/translations/**/*
+  - changed-files:
+      - any-glob-to-any-file: custom_components/openevse/translations/**/*
 docs:
-  - README.md
-  - CONTRIBUTING.md
-  - LICENSE
+  - changed-files:
+      - any-glob-to-any-file:
+          - README.md
+          - CONTRIBUTING.md
+          - LICENSE
 github:
-  - .github/**/*
+  - changed-files:
+      - any-glob-to-any-file: .github/**/*
+
+chore:
+  - head-branch: ['^chore/.*']
+  - any:
+      - title: ['^chore:.*']
+bugfix:
+  - head-branch: ['^fix/.*', '^bugfix/.*']
+  - any:
+      - title: ['^fix:.*']
+feature:
+  - head-branch: ['^feature/.*', '^feat/.*']
+  - any:
+      - title: ['^feat:.*']
+enhancement:
+  - head-branch: ['^refactor/.*']
+  - any:
+      - title: ['^refactor:.*']
+code-quality:
+  - any:
+      - title: ['^tests:.*']
+dependencies:
+  - any:
+      - title: ['^build\(deps\):.*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,12 @@
+backend:
+  - custom_components/openevse/**/*.py
+tests:
+  - tests/**/*
+translations:
+  - custom_components/openevse/translations/**/*
+docs:
+  - README.md
+  - CONTRIBUTING.md
+  - LICENSE
+github:
+  - .github/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+on:
+  pull_request_target:
+    types: [opened, synchronized, reopened]
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labeler
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Pull Request Labeler"
 on:
   pull_request_target:
-    types: [opened, synchronized, reopened]
+    types: [opened, synchronize, reopened]
 
 jobs:
   labeler:

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - edited
-      - synchronized
+      - synchronize
 
 jobs:
   main:

--- a/.github/workflows/pull-request-title.yml
+++ b/.github/workflows/pull-request-title.yml
@@ -1,0 +1,32 @@
+name: "Lint PR title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronized
+
+jobs:
+  main:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed.
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+          # Configure that a scope must be provided.
+          requireScope: false


### PR DESCRIPTION
This PR adds infrastructure for automated PR management:

1. **Automated Labeling**:
   - Created `.github/labeler.yml` with path-based and title-based rules (ported from `release-drafter`).
   - Added `.github/workflows/labeler.yml` using `actions/labeler@v6.1.0`.
2. **PR Title Linting**:
   - Added `.github/workflows/pull-request-title.yml` using `amannn/action-semantic-pull-request@v6.1.1` to ensure titles follow the Conventional Commits specification.

All actions are pinned to verified SHAs for security and reproducibility.
Verified locally with `prek run --all-files`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request labeling with mappings for code areas and branch/title-based labels to improve triage.
  * Added a workflow to apply and sync labels on new and updated pull requests for consistent tracking.
  * Added a pull-request title linting workflow to enforce allowed PR title types and promote consistent commit semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/openevse/pull/599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->