### PR TITLE
feat(switch): add current shaper

### DIFF
--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -450,6 +450,13 @@ SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
     ),
+    "shaper": OpenEVSESwitchEntityDescription(
+        name="Current Shaper",
+        key="shaper_active",
+        toggle_command="toggle_shaper",
+        device_class=SwitchDeviceClass.SWITCH,
+        min_version="4.1.0",
+    ),
 }
 
 # Name, options, command, entity category

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.3.0b0"
+    "python-openevse-http==0.3.1"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.3.1"
+    "python-openevse-http==0.3.2"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.3.1
+python-openevse-http==0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.3.0
+python-openevse-http==0.3.1

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -60,7 +60,7 @@ async def test_setup_entry(hass, test_charger, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -81,7 +81,7 @@ async def test_setup_entry_bad_serial(hass, test_charger_bad_serial, mock_ws_sta
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -133,7 +133,7 @@ async def test_setup_entry_state_change(hass, test_charger, mock_ws_start, caplo
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -165,7 +165,7 @@ async def test_setup_entry_state_change_timeout(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -197,7 +197,7 @@ async def test_setup_entry_state_change_2(hass, test_charger, mock_ws_start, cap
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -234,7 +234,7 @@ async def test_setup_entry_state_change_2_bad_post(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -300,7 +300,7 @@ async def test_setup_entry_v2(hass, test_charger_v2, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -12,7 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.openevse.const import COORDINATOR, DOMAIN, MANAGER
 from custom_components.openevse.switch import OpenEVSESwitch
 
-from .conftest import TEST_URL_CONFIG
+from .conftest import TEST_URL_CONFIG, TEST_URL_STATUS
 from .const import CONFIG_DATA
 
 pytestmark = pytest.mark.asyncio
@@ -39,7 +39,7 @@ async def test_switches(
     await hass.async_block_till_done()
 
     # Ensure all switches are created
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
 
     # Get the coordinator to simulate data updates
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
@@ -131,6 +131,34 @@ async def test_switches(
     state = hass.states.get(entity_id)
     assert state.state == "on"
 
+    # -------------------------------------------------------------------------
+    # 4. Test Current Shaper Switch
+    # -------------------------------------------------------------------------
+    # Initial State: In CHARGER_DATA, "shaper_active" is False, so switch is OFF.
+    entity_id = "switch.openevse_current_shaper"
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+
+    mock_aioclient.post(
+        TEST_URL_STATUS,
+        status=200,
+        body='{"msg": "OK"}',
+    )
+
+    # Action: Turn On
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["shaper_active"] = True
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be ON
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+
 
 async def test_switches_v2(
     hass,
@@ -151,7 +179,7 @@ async def test_switches_v2(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -143,7 +143,7 @@ async def test_switches(
     mock_aioclient.post(
         TEST_URL_SHAPER,
         status=200,
-        body='{"msg": "OK"}',
+        body='{"msg": "Current Shaper state changed"}',
     )
 
     # Action: Turn On

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -12,7 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.openevse.const import COORDINATOR, DOMAIN, MANAGER
 from custom_components.openevse.switch import OpenEVSESwitch
 
-from .conftest import TEST_URL_CONFIG, TEST_URL_STATUS
+from .conftest import TEST_URL_CONFIG
 from .const import CONFIG_DATA
 
 pytestmark = pytest.mark.asyncio
@@ -20,6 +20,7 @@ pytestmark = pytest.mark.asyncio
 CHARGER_NAME = "openevse"
 TEST_URL_OVERRIDE = "http://openevse.test.tld/override"
 TEST_URL_DIVERT = "http://openevse.test.tld/divertmode"
+TEST_URL_SHAPER = "http://openevse.test.tld/shaper"
 
 
 async def test_switches(
@@ -137,27 +138,27 @@ async def test_switches(
     # Initial State: In CHARGER_DATA, "shaper_active" is False, so switch is OFF.
     entity_id = "switch.openevse_current_shaper"
     state = hass.states.get(entity_id)
-    assert state.state == "off"
+    assert state.state == "on"
 
     mock_aioclient.post(
-        TEST_URL_STATUS,
+        TEST_URL_SHAPER,
         status=200,
         body='{"msg": "OK"}',
     )
 
     # Action: Turn On
     await hass.services.async_call(
-        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+        SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
     )
 
     # Simulate update
-    coordinator._data["shaper_active"] = True
+    coordinator._data["shaper_active"] = False
     coordinator.async_set_updated_data(coordinator._data)
     await hass.async_block_till_done()
 
-    # Assert: Entity should now be ON
+    # Assert: Entity should now be OFF
     state = hass.states.get(entity_id)
-    assert state.state == "on"
+    assert state.state == "off"
 
 
 async def test_switches_v2(


### PR DESCRIPTION
This PR implements a new switch for the "Current Shaper" feature, which allows users to toggle the shaper on and off. 

Key changes:
- Bumps `python-openevse-http` to version `0.3.1` to support the `toggle_shaper` function.
- Adds the `Current Shaper` switch to `const.py`.
- Updates switch tests to include verification for the new switch.

Note: The Shaper switch is only available for devices with firmware version 4.1.0 or newer.