### PR TITLE
fix(beta): use set_shaper for current shaper switch

### DIFF
--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -453,7 +453,7 @@ SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
     "shaper": OpenEVSESwitchEntityDescription(
         name="Current Shaper",
         key="shaper_active",
-        toggle_command="toggle_shaper",
+        toggle_command="set_shaper",
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
     ),

--- a/custom_components/openevse/switch.py
+++ b/custom_components/openevse/switch.py
@@ -111,6 +111,8 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
         try:
             if self.toggle_command == "claim":
                 await self._manager.release_claim()
+            elif self.toggle_command == "set_shaper":
+                await self._manager.set_shaper(True)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:
@@ -127,6 +129,8 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
         try:
             if self.toggle_command == "claim":
                 await self._manager.make_claim(state="active")
+            elif self.toggle_command == "set_shaper":
+                await self._manager.set_shaper(False)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -144,9 +144,10 @@ async def test_switches(
         TEST_URL_SHAPER,
         status=200,
         body='{"msg": "Current Shaper state changed"}',
+        repeat=True,
     )
 
-    # Action: Turn On
+    # Action: Turn Off
     await hass.services.async_call(
         SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
     )
@@ -159,6 +160,20 @@ async def test_switches(
     # Assert: Entity should now be OFF
     state = hass.states.get(entity_id)
     assert state.state == "off"
+
+    # Action: Turn On
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["shaper_active"] = True
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be ON
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
 
 
 async def test_switches_v2(


### PR DESCRIPTION
Based on testing, using `set_shaper(True/False)` is more reliable than `toggle_shaper()` because it explicitly sets the desired state rather than relying on the library's internal state tracking, which can get out of sync.

Changes:
- Update `switch.py` to handle `set_shaper` with boolean arguments.
- Update `const.py` to use `set_shaper` for the shaper switch.

Verified with tests using `python-openevse-http==0.3.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved shaper switch behavior to ensure proper command execution for on/off states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/openevse/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->