### PR TITLE
chore: adjust autolabeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,41 +1,35 @@
-backend:
-  - changed-files:
-      - any-glob-to-any-file: custom_components/openevse/**/*.py
-tests:
-  - changed-files:
-      - any-glob-to-any-file: tests/**/*
-translations:
-  - changed-files:
-      - any-glob-to-any-file: custom_components/openevse/translations/**/*
-docs:
+chore:
+  - head-branch: ['^chore[/|-].*']
+
+bugfix:
+  - head-branch: ['^fix[/|-].*', '^bugfix[/|-].*']
+
+feature:
+  - head-branch: ['^feature[/|-].*', '^feat[/|-].*']
+
+enhancement:
+  - head-branch: ['^refactor[/|-].*']
+
+documentation:
+  - head-branch: ['^docs[/|-].*']
   - changed-files:
       - any-glob-to-any-file:
           - README.md
           - CONTRIBUTING.md
           - LICENSE
+          - docs/**/*
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file: tests/**/*
+
+translations:
+  - changed-files:
+      - any-glob-to-any-file: custom_components/openevse/translations/**/*
+
 github:
   - changed-files:
       - any-glob-to-any-file: .github/**/*
 
-chore:
-  - head-branch: ['^chore/.*']
-  - any:
-      - title: ['^chore:.*']
-bugfix:
-  - head-branch: ['^fix/.*', '^bugfix/.*']
-  - any:
-      - title: ['^fix:.*']
-feature:
-  - head-branch: ['^feature/.*', '^feat/.*']
-  - any:
-      - title: ['^feat:.*']
-enhancement:
-  - head-branch: ['^refactor/.*']
-  - any:
-      - title: ['^refactor:.*']
-code-quality:
-  - any:
-      - title: ['^tests:.*']
 dependencies:
-  - any:
-      - title: ['^build\(deps\):.*']
+  - head-branch: ['^deps[/|-].*', '^dependabot/.*']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,17 +19,13 @@ documentation:
           - LICENSE
           - docs/**/*
 
-tests:
+has-tests:
   - changed-files:
       - any-glob-to-any-file: tests/**/*
 
 translations:
   - changed-files:
       - any-glob-to-any-file: custom_components/openevse/translations/**/*
-
-github:
-  - changed-files:
-      - any-glob-to-any-file: .github/**/*
 
 dependencies:
   - head-branch: ['^deps[/|-].*', '^dependabot/.*']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,23 +4,43 @@ change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 autolabeler:
   - label: "chore"
+    branch:
+      - "chore-*"
+      - "docs-*"
     title:
-      - "/chore:/i"
+      - "/^chore(\\s*\\(.*\\))?:/i"
+      - "/^docs(\\s*\\(.*\\))?:/i"
+  - label: "documentation"
+    branch:
+      - "docs-*"
+    title:
+      - "/^docs(\\s*\\(.*\\))?:/i"
   - label: "bugfix"
+    branch:
+      - "fix-*"
     title:
-      - "/fix:/i"
+      - "/^fix(\\s*\\(.*\\))?:/i"
   - label: "feature"
+    branch:
+      - "feat-*"
     title:
-      - "/feat:/i"
+      - "/^feat(\\s*\\(.*\\))?:/i"
   - label: "enhancement"
+    branch:
+      - "refactor-*"
     title:
-      - "/refactor:/i"
+      - "/^refactor(\\s*\\(.*\\))?:/i"
   - label: "code-quality"
+    branch:
+      - "test-*"
     title:
-      - "/tests:/i"
+      - "/^test(s)?(\\s*\\(.*\\))?:/i"
   - label: "dependencies"
+    branch:
+      - "deps-*"
     title:
-      - "/build(deps):/i"
+      - "/^build\\(deps\\):/i"
+      - "/^chore\\(deps\\):/i"
 categories:
   - title: "💥 Breaking Change 💥"
     labels:
@@ -39,13 +59,16 @@ categories:
   - title: "🔧 Maintenance 🔧"
     labels:
       - "chore"
+      - "docs"
+      - "documentation"
+    collapse-after: 3
   - title: "🎓 Code Quality 🎓"
     labels:
       - "code-quality"
   - title: "🔩 Dependency 🔩"
     labels:
       - "dependencies"
-    collapse-after: 1
+    collapse-after: 3
 
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/openevse/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/openevse/releases/$RESOLVED_VERSION)


### PR DESCRIPTION
Adjusted the autolabeler configuration to match standard Python repository patterns used in your other repositories (like `ha-gasbuddy`).

Changes:
- Removed the redundant `backend` label for `.py` files.
- Standardized branch prefix patterns (supporting both `/` and `-`).
- Aligned `labeler.yml` and `release-drafter.yml` categories and labels.
- Removed unsupported configuration keys from `labeler.yml`.
- Renamed `docs` to `documentation` for better alignment with other repos.