### PR TITLE
chore: add stale PR/Issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Andrew Grimberg <tykeal@bardicgrove.org>
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Stale'
+
+# yamllint disable-line rule:truthy
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    name: 'Stale'
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        with:
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            recent activity. It will be closed if no further activity occurs. Thank
+            you for your contributions.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs. Thank you for your contributions.
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'bug,pinned,security'
+          exempt-pr-labels: 'bug,pinned,security'


### PR DESCRIPTION
This PR adds a stale PR/Issue workflow to the repository. 
- Pinned to `actions/stale@v9.1.0` (SHA: `5bef64f19d7facfb25b37b414482c7164d639639`)
- Includes `step-security/harden-runner`
- Explicit permissions for security
- Configured to mark issues/PRs as stale after 60 days of inactivity and close after 7 days.