### PR TITLE
chore: bump python-openevse-http to 0.3.3

### DIFF
--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.3.2"
+    "python-openevse-http==0.3.3"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.3.2
+python-openevse-http==0.3.3


### PR DESCRIPTION
Bumps the `python-openevse-http` dependency version to `0.3.3` to resolve issues with the "Current Shaper" feature.

### Highlights in `python-openevse-http` 0.3.3:
- **Shaper Activation Fix**: Corrects the shaper activation command payload (`{"shaper": mode}`) and encodes RAPI parameters as form data rather than JSON, enabling successful shaper toggle on the charger.
- **State Synchronization**: Updates local state immediately after sending successful `set_shaper` and `set_divert_mode` commands to keep the state in sync.
- **Log Level Cleanup**: Standardizes logging for missing optional sensors and diagnostics.

This version bump resolves the issue where the shaper switch toggles successfully in Home Assistant but fails to actually activate on the device.