### PR TITLE
fix(light): enforce min_version requirement for availability

### DIFF
--- a/custom_components/openevse/light.py
+++ b/custom_components/openevse/light.py
@@ -100,6 +100,13 @@ class OpenEVSELight(CoordinatorEntity, LightEntity):
 
         return info
 
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if self._min_version and not self.manager.version_check(self._min_version):
+            return False
+        return self.coordinator.last_update_success
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -179,3 +179,29 @@ async def test_light_connection_error(
             blocking=True,
         )
     assert "Error connecting to device" in caplog.text
+
+
+async def test_light_available_version_check(hass, test_charger, mock_ws_start):
+    """Test light availability version checks."""
+    entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_DATA)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
+    entity_id = "light.openevse_led_brightness"
+
+    # With version_check returning True, the entity should be available
+    with patch.object(manager, "version_check", return_value=True):
+        coordinator.async_update_listeners()
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state != "unavailable"
+
+    # With version_check returning False, the entity should be unavailable
+    with patch.object(manager, "version_check", return_value=False):
+        coordinator.async_update_listeners()
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state.state == "unavailable"


### PR DESCRIPTION
This PR implements the missing `available` property in `OpenEVSELight` class to respect the `min_version` check specified on entity descriptions (e.g. `led_brightness` requires `"4.1.0"`). It also adds a corresponding test to verify entity availability behavior under version constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced light entity availability to reflect OpenEVSE version requirements and coordinator connectivity status. Brightness and control functions remain unchanged.

* **Tests**
  * Added test verifying light entity availability state transitions based on version compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/openevse/pull/612?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->