### PR TITLE
feat: log skipped service registration on older firmware

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -243,6 +243,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if manager.version_check("4.1.0"):
         services = OpenEVSEServices(hass, config_entry)
         services.async_register()
+    else:
+        logger.debug(
+            "Skipping service registration: firmware version does not meet "
+            "minimum requirement (4.1.0)"
+        )
 
     sensors = []
     options = config_entry.options

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -317,7 +317,10 @@ async def test_setup_entry_old_firmware(hass, test_charger, mock_ws_start, caplo
 
     # Patch version_check to return False (simulating firmware < 4.1.0)
     # The integration uses the 'manager' object which is an instance of OpenEVSE
-    with patch("custom_components.openevse.OpenEVSE.version_check", return_value=False):
+    with (
+        patch("custom_components.openevse.OpenEVSE.version_check", return_value=False),
+        caplog.at_level(logging.DEBUG),
+    ):
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -306,7 +306,7 @@ async def test_setup_entry_v2(hass, test_charger_v2, mock_ws_start):
     assert len(entries) == 1
 
 
-async def test_setup_entry_old_firmware(hass, test_charger, mock_ws_start):
+async def test_setup_entry_old_firmware(hass, test_charger, mock_ws_start, caplog):
     """Test setup with older firmware where services are not registered."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -325,6 +325,10 @@ async def test_setup_entry_old_firmware(hass, test_charger, mock_ws_start):
         # Verify that a service specific to > 4.1.0 is NOT registered
         # 'set_override' is one of the services registered in services.py
         assert not hass.services.has_service(DOMAIN, "set_override")
+        assert (
+            "Skipping service registration: firmware version does not meet "
+            "minimum requirement (4.1.0)" in caplog.text
+        )
 
 
 async def test_setup_entry_state_change_unavailable(


### PR DESCRIPTION
This PR adds a debug level log message when the custom services registration is skipped because the device's firmware does not satisfy the minimum required version (`4.1.0`). It also updates the existing test `test_setup_entry_old_firmware` to verify that the debug log message is successfully generated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Properly handle firmware versions below 4.1.0 by skipping service registration and emitting a debug message explaining the minimum requirement.

* **Tests**
  * Expanded test coverage to verify older-firmware behavior, including assertion that the debug log is emitted when services are skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/openevse/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->