### PR TITLE
fix: gracefully handle manual override release failures

### DIFF
--- a/custom_components/openevse/select.py
+++ b/custom_components/openevse/select.py
@@ -112,7 +112,9 @@ class OpenEVSESelect(CoordinatorEntity, SelectEntity):
                                 "No active override to clear."
                             )
                         else:
-                            raise
+                            raise HomeAssistantError(
+                                f"Error communicating with device: {err}"
+                            ) from err
                 return None
 
             if self._command.startswith("$"):

--- a/custom_components/openevse/select.py
+++ b/custom_components/openevse/select.py
@@ -101,8 +101,18 @@ class OpenEVSESelect(CoordinatorEntity, SelectEntity):
                     response = await charger.set_override(state=option.lower())
                     self.coordinator.logger.debug("Select response: %s", response)
                 else:
-                    response = await charger.clear_override()
-                    self.coordinator.logger.debug("Select Auto response: %s", response)
+                    try:
+                        response = await charger.clear_override()
+                        self.coordinator.logger.debug(
+                            "Select Auto response: %s", response
+                        )
+                    except RuntimeError as err:
+                        if "Failed to release manual override" in str(err):
+                            self.coordinator.logger.debug(
+                                "No active override to clear."
+                            )
+                        else:
+                            raise
                 return None
 
             if self._command.startswith("$"):

--- a/custom_components/openevse/services.py
+++ b/custom_components/openevse/services.py
@@ -276,6 +276,11 @@ class OpenEVSEServices:
                     logger.debug("Override clear command sent.")
                 except CONNECTION_ERRORS as err:
                     logger.error(CONNECTION_ERROR, err)
+                except RuntimeError as err:
+                    if "Failed to release manual override" in str(err):
+                        logger.debug("No active override to clear.")
+                    else:
+                        raise
             except KeyError as err:
                 logger.error("Error locating configuration: %s", err)
 

--- a/custom_components/openevse/services.py
+++ b/custom_components/openevse/services.py
@@ -11,6 +11,7 @@ from homeassistant.core import (
     SupportsResponse,
     callback,
 )
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
@@ -280,7 +281,9 @@ class OpenEVSEServices:
                     if "Failed to release manual override" in str(err):
                         logger.debug("No active override to clear.")
                     else:
-                        raise
+                        raise HomeAssistantError(
+                            f"Error communicating with device: {err}"
+                        ) from err
             except KeyError as err:
                 logger.error("Error locating configuration: %s", err)
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -485,3 +485,39 @@ async def test_select_clear_override_not_active(
         )
         await hass.async_block_till_done()
         assert "No active override to clear." in caplog.text
+
+
+async def test_select_clear_override_other_runtime_error(
+    hass,
+    test_charger,
+    mock_ws_start,
+    mock_aioclient,
+):
+    """Test select platform when clearing override raises unexpected RuntimeError."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "select.openevse_override_state"
+
+    mock_aioclient.delete(
+        TEST_URL_OVERRIDE,
+        status=500,
+        body='{"msg": "Some other server error"}',
+    )
+
+    servicedata = {
+        "entity_id": entity_id,
+        "option": "auto",
+    }
+
+    with pytest.raises(HomeAssistantError, match="Error communicating with device"):
+        await hass.services.async_call(
+            SELECT_DOMAIN, SERVICE_SELECT_OPTION, servicedata, blocking=True
+        )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -446,3 +446,42 @@ async def test_select_connection_error(
             blocking=True,
         )
     assert "Error connecting to device" in caplog.text
+
+
+async def test_select_clear_override_not_active(
+    hass,
+    test_charger,
+    mock_ws_start,
+    mock_aioclient,
+    caplog,
+):
+    """Test select platform when clearing override and it's already cleared."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "select.openevse_override_state"
+
+    mock_aioclient.delete(
+        TEST_URL_OVERRIDE,
+        status=500,
+        body='{"msg": "Failed to release manual override"}',
+    )
+
+    servicedata = {
+        "entity_id": entity_id,
+        "option": "auto",
+    }
+
+    with caplog.at_level(logging.DEBUG):
+        await hass.services.async_call(
+            SELECT_DOMAIN, SERVICE_SELECT_OPTION, servicedata, blocking=True
+        )
+        await hass.async_block_till_done()
+        assert "No active override to clear." in caplog.text

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -385,6 +385,50 @@ async def test_clear_override(
         assert "Override clear command sent." in caplog.text
 
 
+async def test_clear_override_not_active(
+    hass,
+    test_charger_services,
+    mock_aioclient,
+    mock_ws_start,
+    entity_registry: er.EntityRegistry,
+    caplog,
+):
+    """Test release claim service call when no override is active."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+    mock_aioclient.delete(
+        TEST_URL_OVERRIDE,
+        status=500,
+        body='{"msg": "Failed to release manual override"}',
+    )
+    mock_aioclient.get(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body="{}",
+        repeat=True,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("sensor.openevse_station_status")
+    assert entry
+    assert entry.device_id
+
+    # setup service call
+    with caplog.at_level(logging.DEBUG):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_OVERRIDE,
+            {ATTR_DEVICE_ID: entry.device_id},
+            blocking=True,
+        )
+        assert "No active override to clear." in caplog.text
+
+
 async def test_list_overrides(
     hass,
     test_charger_services,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -427,6 +428,49 @@ async def test_clear_override_not_active(
             blocking=True,
         )
         assert "No active override to clear." in caplog.text
+
+
+async def test_clear_override_other_runtime_error(
+    hass,
+    test_charger_services,
+    mock_aioclient,
+    mock_ws_start,
+    entity_registry: er.EntityRegistry,
+):
+    """Test release claim service call with an unexpected RuntimeError."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+    # Status code 500 with another message
+    mock_aioclient.delete(
+        TEST_URL_OVERRIDE,
+        status=500,
+        body='{"msg": "Some other server error"}',
+    )
+    mock_aioclient.get(
+        TEST_URL_OVERRIDE,
+        status=200,
+        body="{}",
+        repeat=True,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get("sensor.openevse_station_status")
+    assert entry
+    assert entry.device_id
+
+    # setup service call, expects HomeAssistantError
+    with pytest.raises(HomeAssistantError, match="Error communicating with device"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_OVERRIDE,
+            {ATTR_DEVICE_ID: entry.device_id},
+            blocking=True,
+        )
 
 
 async def test_list_overrides(


### PR DESCRIPTION
Fixes #619

This PR updates the services wrapper and the select control to catch `RuntimeError` during the `clear_override` call. If the error contains `"Failed to release manual override"`, it is logged as debug/ignored as the override is already cleared. Other `RuntimeError`s are converted and raised as `HomeAssistantError` so Home Assistant can handle them cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced error handling for manual override operations – the integration now correctly differentiates between scenarios where no active override exists versus device communication failures, with appropriate logging and error reporting for each case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/firstof9/openevse/pull/620?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->