### PR TITLE
chore: align autolabeler with keymaster rules

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -43,45 +43,26 @@ autolabeler:
     title:
       - '/^[a-z]+(\([^)]+\))?!:/i'
   - label: "feature"
-    branch:
-      - "feat-*"
-      - "feature-*"
     title:
       - '/^feat(\([^)]+\))?:/i'
   - label: "bugfix"
-    branch:
-      - "fix-*"
-      - "bugfix-*"
     title:
       - '/^fix(\([^)]+\))?:/i'
   - label: "refactor"
-    branch:
-      - "refactor-*"
     title:
       - '/^refactor(\([^)]+\))?:/i'
   - label: "code-quality"
-    branch:
-      - "test-*"
     title:
       - '/^test(\([^)]+\))?:/i'
   - label: "CI"
     title:
       - '/^ci(\([^)]+\))?:/i'
   - label: "chore"
-    branch:
-      - "chore-*"
     title:
       - '/^chore(\([^)]+\))?:/i'
   - label: "documentation"
-    branch:
-      - "docs-*"
     title:
       - '/^docs(\([^)]+\))?:/i'
-    files:
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "LICENSE"
-      - "docs/**/*"
   - label: "style"
     title:
       - '/^style(\([^)]+\))?:/i'
@@ -95,9 +76,6 @@ autolabeler:
     title:
       - '/^build(\([^)]+\))?:/i'
   - label: "dependencies"
-    branch:
-      - "deps-*"
-      - "dependabot/*"
     title:
       - "/^build\\(deps\\):/i"
       - "/^chore\\(deps\\):/i"


### PR DESCRIPTION
This PR updates the `release-drafter` configuration to match pull requests to their labels strictly using the PR title prefix (e.g. Conventional Commits format). This aligns the configuration with the autolabeler behavior in `firstof9/keymaster` and prevents incorrect labeling based on branch names or file paths.