### PR TITLE
chore: bump python-openevse-http to 0.3.5

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -10,11 +10,13 @@ on:
       - opened
       - synchronize
       - reopened
+      - edited
   pull_request_target:
     types:
       - opened
       - synchronize
       - reopened
+      - edited
 
 permissions: {}
 

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.3.4"
+    "python-openevse-http==0.3.5"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.3.4
+python-openevse-http==0.3.5


### PR DESCRIPTION
## Description

- Bump `python-openevse-http` library dependency to `0.3.5` to resolve issue with command responses (such as "Updated", "Created", "Deleted", and "restart gateway") not being recognized as success messages.
- Add `edited` type to `pull_request` and `pull_request_target` triggers in the `autolabeler` workflow to ensure labels update on PR edits.

Fixes #616

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules