### PR TITLE
feat: add firmware update trigger support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The **OpenEVSE** Home Assistant integration provides direct, local control over 
 - ☀️ **Solar PV Divert Mode**: Dynamically adjust charging current based on your home's excess solar power.
 - 🛡️ **Claim & Override System**: Safely queue, override, or limit charge rates and sessions using Home Assistant services or the UI.
 - 🎨 **LED Brightness Control**: Manage the charger's LED display brightness directly (firmware v4.1.0+).
-- 🆙 **Update Notification**: Track charger firmware updates and review release notes inside Home Assistant.
+- 🆙 **Firmware Updates**: Track, download, and install charger firmware updates directly within Home Assistant.
 
 ---
 
@@ -103,7 +103,7 @@ The integration sets up the following platforms and entities:
 | `select` | • Charge Rate<br>• Divert Mode (`fast` / `eco`) | Select charge limits, divert types, or override status. |
 | `sensor` | • Station Status<br>• Charging Status<br>• Charging Voltage / Current<br>• Current Power Usage (Actual & Calc)<br>• Usage this Session (Energy)<br>• Total Usage (Energy)<br>• WiFi Signal Strength<br>• Temperatures (Ambient, ESP32, RTC, IR)<br>• Vehicle Battery Level (SOC) (v4.1.0+) | Sensor telemetry, stats, and diagnostic measurements. |
 | `switch` | • Sleep Mode<br>• Manual Override (v4.1.0+)<br>• Solar PV Divert (v4.1.0+)<br>• Current Shaper (v4.1.0+) | Controls to toggle operational modes of the EVSE. |
-| `update` | • OpenEVSE Update | Detects controller firmware updates and provides release notes. |
+| `update` | • OpenEVSE Update | Detects controller firmware updates, provides release notes, and installs updates. |
 
 ---
 

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.3.5"
+    "python-openevse-http==0.4.0"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -18,8 +18,9 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from openevsehttp.__main__ import OpenEVSE
 
-from .const import CONF_NAME, COORDINATOR, DOMAIN, FW_COORDINATOR
+from .const import CONF_NAME, COORDINATOR, DOMAIN, FW_COORDINATOR, MANAGER
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,7 +31,8 @@ async def async_setup_entry(
     """Set up update entities for Netgear component."""
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
     fw_coordinator = hass.data[DOMAIN][entry.entry_id][FW_COORDINATOR]
-    entities = [OpenEVSEUpdateEntity(coordinator, fw_coordinator, entry)]
+    manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
+    entities = [OpenEVSEUpdateEntity(coordinator, fw_coordinator, entry, manager)]
 
     async_add_entities(entities)
 
@@ -48,6 +50,7 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         coordinator: DataUpdateCoordinator,
         fw_coordinator: DataUpdateCoordinator,
         config: ConfigEntry,
+        manager: OpenEVSE,
     ) -> None:
         """Initialize a OpenEVSE device."""
         super().__init__(fw_coordinator)
@@ -57,6 +60,7 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         self._attr_name = f"{config.data[CONF_NAME]} Update"
         self._base_unique_id = config.entry_id
         self._attr_unique_id = f"{self._base_unique_id}.update"
+        self._manager = manager
 
     @property
     def device_info(self) -> dict:
@@ -113,7 +117,7 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
             raise HomeAssistantError("No firmware download URL available to install")
 
         try:
-            await self.coordinator._manager.update_firmware(firmware_url=firmware_url)
+            await self._manager.update_firmware(firmware_url=firmware_url)
         except Exception as err:
             raise HomeAssistantError(
                 f"Failed to install firmware update: {err}"

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -12,6 +12,7 @@ from homeassistant.components.update import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -108,4 +109,12 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
             if self.fw_coordinator.data
             else None
         )
-        await self.coordinator._manager.update_firmware(firmware_url=firmware_url)
+        if not firmware_url:
+            raise HomeAssistantError("No firmware download URL available to install")
+
+        try:
+            await self.coordinator._manager.update_firmware(firmware_url=firmware_url)
+        except Exception as err:
+            raise HomeAssistantError(
+                f"Failed to install firmware update: {err}"
+            ) from err

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.update import (
     UpdateDeviceClass,
@@ -37,7 +38,9 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
     """Update entity for a OpenEVSE device."""
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
-    _attr_supported_features = UpdateEntityFeature.RELEASE_NOTES
+    _attr_supported_features = (
+        UpdateEntityFeature.RELEASE_NOTES | UpdateEntityFeature.INSTALL
+    )
 
     def __init__(
         self,
@@ -95,3 +98,14 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         if self.fw_coordinator.data is not None:
             return self.fw_coordinator.data.get("release_url")
         return None
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        firmware_url = (
+            self.fw_coordinator.data.get("browser_download_url")
+            if self.fw_coordinator.data
+            else None
+        )
+        await self.coordinator._manager.update_firmware(firmware_url=firmware_url)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.3.5
+python-openevse-http==0.4.0

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,7 @@
 """Test OpenEVSE update platform."""
 
+from unittest.mock import AsyncMock
+
 import pytest
 from homeassistant.components.update import (
     ATTR_INSTALLED_VERSION,
@@ -71,3 +73,29 @@ async def test_update_coverage_gaps(hass, test_charger, mock_ws_start):
     # Test installed_version when coordinator data is missing
     coordinator.data = None
     assert update.installed_version is None
+
+
+async def test_update_install(hass, test_charger, mock_ws_start):
+    """Test update install service."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = hass.data[DOMAIN][entry.entry_id]["manager"]
+    manager.update_firmware = AsyncMock()
+
+    entity_id = "update.openevse_update"
+    await hass.services.async_call(
+        UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
+    )
+
+    assert manager.update_firmware.called
+    manager.update_firmware.assert_called_once_with(
+        firmware_url="https://github.com/OpenEVSE/ESP32_WiFi_V4.x/releases/download/4.1.7/openevse_wifi_v1.bin"
+    )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -9,6 +9,7 @@ from homeassistant.components.update import (
     ATTR_RELEASE_URL,
 )
 from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
+from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openevse.const import COORDINATOR, DOMAIN, FW_COORDINATOR
@@ -117,8 +118,6 @@ async def test_update_install_no_url(hass, test_charger, mock_ws_start):
     fw_coordinator.data = {}
 
     entity_id = "update.openevse_update"
-    from homeassistant.exceptions import HomeAssistantError
-
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
@@ -141,8 +140,6 @@ async def test_update_install_failure(hass, test_charger, mock_ws_start):
     manager.update_firmware = AsyncMock(side_effect=RuntimeError("Update failed"))
 
     entity_id = "update.openevse_update"
-    from homeassistant.exceptions import HomeAssistantError
-
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -99,3 +99,51 @@ async def test_update_install(hass, test_charger, mock_ws_start):
     manager.update_firmware.assert_called_once_with(
         firmware_url="https://github.com/OpenEVSE/ESP32_WiFi_V4.x/releases/download/4.1.7/openevse_wifi_v1.bin"
     )
+
+
+async def test_update_install_no_url(hass, test_charger, mock_ws_start):
+    """Test update install service with no URL."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    fw_coordinator = hass.data[DOMAIN][entry.entry_id][FW_COORDINATOR]
+    fw_coordinator.data = {}
+
+    entity_id = "update.openevse_update"
+    from homeassistant.exceptions import HomeAssistantError
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
+        )
+
+
+async def test_update_install_failure(hass, test_charger, mock_ws_start):
+    """Test update install service when update fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = hass.data[DOMAIN][entry.entry_id]["manager"]
+    manager.update_firmware = AsyncMock(side_effect=RuntimeError("Update failed"))
+
+    entity_id = "update.openevse_update"
+    from homeassistant.exceptions import HomeAssistantError
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
+        )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -115,13 +115,17 @@ async def test_update_install_no_url(hass, test_charger, mock_ws_start):
     await hass.async_block_till_done()
 
     fw_coordinator = hass.data[DOMAIN][entry.entry_id][FW_COORDINATOR]
-    fw_coordinator.data = {}
+    fw_coordinator.data = {
+        "latest_version": "4.1.8",
+        "browser_download_url": None,
+    }
 
     entity_id = "update.openevse_update"
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await hass.services.async_call(
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
         )
+    assert str(excinfo.value) == "No firmware download URL available to install"
 
 
 async def test_update_install_failure(hass, test_charger, mock_ws_start):

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -12,7 +12,12 @@ from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.openevse.const import COORDINATOR, DOMAIN, FW_COORDINATOR
+from custom_components.openevse.const import (
+    COORDINATOR,
+    DOMAIN,
+    FW_COORDINATOR,
+    MANAGER,
+)
 from custom_components.openevse.update import OpenEVSEUpdateEntity
 from tests.typing import WebSocketGenerator
 
@@ -68,8 +73,9 @@ async def test_update_coverage_gaps(hass, test_charger, mock_ws_start):
 
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
     fw_coordinator = hass.data[DOMAIN][entry.entry_id][FW_COORDINATOR]
+    manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
 
-    update = OpenEVSEUpdateEntity(coordinator, fw_coordinator, entry)
+    update = OpenEVSEUpdateEntity(coordinator, fw_coordinator, entry, manager)
 
     # Test installed_version when coordinator data is missing
     coordinator.data = None
@@ -144,7 +150,8 @@ async def test_update_install_failure(hass, test_charger, mock_ws_start):
     manager.update_firmware = AsyncMock(side_effect=RuntimeError("Update failed"))
 
     entity_id = "update.openevse_update"
-    with pytest.raises(HomeAssistantError):
+    with pytest.raises(HomeAssistantError) as excinfo:
         await hass.services.async_call(
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
         )
+    assert "Failed to install firmware update" in str(excinfo.value)


### PR DESCRIPTION
## Description

This PR adds support to trigger/install firmware updates directly from the Home Assistant update platform, leveraging the new `update_firmware` API introduced in `python-openevse-http` 0.4.0.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Firmware installation is now supported for OpenEVSE devices. Users can install controller firmware updates directly through Home Assistant's update service, including error handling for failed installations and missing download URLs.

* **Documentation**
  * Updated feature documentation to describe firmware update detection, release notes, and installation capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->