### PR TITLE
feat: Add firmware update progress reporting to update platform

### DIFF
--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.4.0"
+    "python-openevse-http==0.4.1"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -42,7 +42,9 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
 
     _attr_device_class = UpdateDeviceClass.FIRMWARE
     _attr_supported_features = (
-        UpdateEntityFeature.RELEASE_NOTES | UpdateEntityFeature.INSTALL
+        UpdateEntityFeature.RELEASE_NOTES
+        | UpdateEntityFeature.INSTALL
+        | UpdateEntityFeature.PROGRESS
     )
 
     def __init__(
@@ -61,6 +63,13 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         self._base_unique_id = config.entry_id
         self._attr_unique_id = f"{self._base_unique_id}.update"
         self._manager = manager
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self.async_write_ha_state)
+        )
 
     @property
     def device_info(self) -> dict:
@@ -103,6 +112,16 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         if self.fw_coordinator.data is not None:
             return self.fw_coordinator.data.get("release_url")
         return None
+
+    @property
+    def in_progress(self) -> bool:
+        """Update installation progress."""
+        return self._manager.ota_update
+
+    @property
+    def update_percentage(self) -> int | None:
+        """Update installation progress percentage."""
+        return self._manager.ota_progress
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.4.0
+python-openevse-http==0.4.1

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,12 +1,14 @@
 """Test OpenEVSE update platform."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from homeassistant.components.update import (
+    ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,
     ATTR_LATEST_VERSION,
     ATTR_RELEASE_URL,
+    ATTR_UPDATE_PERCENTAGE,
 )
 from homeassistant.components.update import DOMAIN as UPDATE_DOMAIN
 from homeassistant.exceptions import HomeAssistantError
@@ -155,3 +157,44 @@ async def test_update_install_failure(hass, test_charger, mock_ws_start):
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
         )
     assert "Failed to install firmware update" in str(excinfo.value)
+
+
+async def test_update_progress(hass, test_charger, mock_ws_start):
+    """Test update entity progress attributes."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = "update.openevse_update"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_IN_PROGRESS] is False
+    assert state.attributes.get(ATTR_UPDATE_PERCENTAGE) is None
+
+    # Set update in progress
+    with (
+        patch(
+            "openevsehttp.__main__.OpenEVSE.ota_update",
+            new_callable=PropertyMock,
+        ) as mock_ota_update,
+        patch(
+            "openevsehttp.__main__.OpenEVSE.ota_progress",
+            new_callable=PropertyMock,
+        ) as mock_ota_progress,
+    ):
+        mock_ota_update.return_value = True
+        mock_ota_progress.return_value = 50
+
+        coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+        await coordinator.async_refresh()
+        await hass.async_block_till_done()
+
+        state = hass.states.get(entity_id)
+        assert state.attributes[ATTR_IN_PROGRESS] is True
+        assert state.attributes[ATTR_UPDATE_PERCENTAGE] == 50


### PR DESCRIPTION
## Description

This PR updates the dependency `python-openevse-http` to version `0.4.1` to enable support for firmware update progress reporting. It implements progress tracking in the `update` platform entity by adding the `UpdateEntityFeature.PROGRESS` flag and exposing `in_progress` and `update_percentage` properties. A coordinator listener is also registered on the update entity to ensure the UI updates dynamically whenever status updates are received (via periodic polling or WebSocket pushes).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firmware update entity now displays in-progress status and update progress percentage during updates

* **Dependencies**
  * Updated python-openevse-http dependency to version 0.4.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->