### PR TITLE
feat: Add firmware update progress reporting to update platform

### DIFF
--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==0.4.1"
+    "python-openevse-http==0.4.2"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from asyncio import sleep as async_sleep
 from typing import Any
 
 from homeassistant.components.update import (
@@ -141,3 +142,31 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
             raise HomeAssistantError(
                 f"Failed to install firmware update: {err}"
             ) from err
+
+        self.hass.async_create_background_task(
+            self._async_poll_update_progress(),
+            "openevse_update_progress_polling",
+        )
+
+    async def _async_poll_update_progress(self) -> None:
+        """Poll the status endpoint to track update progress."""
+        _LOGGER.debug("Starting update progress polling")
+        for _ in range(150):
+            await async_sleep(2)
+            try:
+                url = f"{self._manager.url}status"
+                response = await self._manager.process_request(url, method="get")
+                if isinstance(response, dict) and "error" not in response:
+                    self._manager._status = dict(response)
+                    _LOGGER.debug(
+                        "Update progress poll status: %s", self._manager._status
+                    )
+                    await self.coordinator.websocket_update()
+                    if not self._manager.ota_update:
+                        _LOGGER.debug("Update complete, stopping progress polling")
+                        break
+            except Exception as err:
+                _LOGGER.debug(
+                    "Error polling update progress (expected during reboot): %s",
+                    err,
+                )

--- a/custom_components/openevse/update.py
+++ b/custom_components/openevse/update.py
@@ -154,17 +154,11 @@ class OpenEVSEUpdateEntity(CoordinatorEntity, UpdateEntity):
         for _ in range(150):
             await async_sleep(2)
             try:
-                url = f"{self._manager.url}status"
-                response = await self._manager.process_request(url, method="get")
-                if isinstance(response, dict) and "error" not in response:
-                    self._manager._status = dict(response)
-                    _LOGGER.debug(
-                        "Update progress poll status: %s", self._manager._status
-                    )
-                    await self.coordinator.websocket_update()
-                    if not self._manager.ota_update:
-                        _LOGGER.debug("Update complete, stopping progress polling")
-                        break
+                await self._manager.update(force_status=True)
+                await self.coordinator.websocket_update()
+                if not self._manager.ota_update:
+                    _LOGGER.debug("Update complete, stopping progress polling")
+                    break
             except Exception as err:
                 _LOGGER.debug(
                     "Error polling update progress (expected during reboot): %s",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==0.4.1
+python-openevse-http==0.4.2

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -240,15 +240,28 @@ async def test_update_polling(hass, test_charger, mock_ws_start):
 
     manager.process_request = mock_process_request
 
-    with patch("custom_components.openevse.update.async_sleep") as mock_sleep:
+    async def mock_sleep_func(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    mock_sleep = AsyncMock(side_effect=mock_sleep_func)
+
+    with patch("custom_components.openevse.update.async_sleep", new=mock_sleep):
         await hass.services.async_call(
             UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
         )
-        # Give the background task time to run its iterations
-        for _ in range(50):
-            if poll_count == 3:
-                break
-            await asyncio.sleep(0.01)
+        await hass.async_block_till_done()
+
+        # Find and await the background polling task to ensure deterministic execution
+        bg_tasks = [
+            t
+            for t in asyncio.all_tasks()
+            if t.get_name() == "openevse_update_progress_polling"
+        ]
+        if bg_tasks:
+            await asyncio.gather(*bg_tasks)
 
         assert poll_count == 3
-        assert mock_sleep.call_count == 3
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.attributes[ATTR_IN_PROGRESS] is False
+        assert state.attributes.get(ATTR_UPDATE_PERCENTAGE) is None

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -221,7 +221,8 @@ async def test_update_polling(hass, test_charger, mock_ws_start):
     entity_id = "update.openevse_update"
 
     # Mock process_request to return ota_update=1 on first poll,
-    # then ota_update=0 on second poll
+    # raise an exception on second poll (to test recovery/reboot),
+    # then return ota_update=0 on third poll
     poll_count = 0
     original_process_request = manager.process_request
 
@@ -231,6 +232,8 @@ async def test_update_polling(hass, test_charger, mock_ws_start):
             poll_count += 1
             if poll_count == 1:
                 return {"ota_update": 1, "ota_progress": 45}
+            elif poll_count == 2:
+                raise RuntimeError("Connection error during reboot")
             else:
                 return {"ota_update": 0}
         return await original_process_request(url, method, data, rapi)
@@ -243,9 +246,9 @@ async def test_update_polling(hass, test_charger, mock_ws_start):
         )
         # Give the background task time to run its iterations
         for _ in range(50):
-            if poll_count == 2:
+            if poll_count == 3:
                 break
             await asyncio.sleep(0.01)
 
-        assert poll_count == 2
-        assert mock_sleep.call_count == 2
+        assert poll_count == 3
+        assert mock_sleep.call_count == 3

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,6 @@
 """Test OpenEVSE update platform."""
 
+import asyncio
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
@@ -100,9 +101,11 @@ async def test_update_install(hass, test_charger, mock_ws_start):
     manager.update_firmware = AsyncMock()
 
     entity_id = "update.openevse_update"
-    await hass.services.async_call(
-        UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
-    )
+    with patch("custom_components.openevse.update.async_sleep"):
+        await hass.services.async_call(
+            UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
+        )
+        await hass.async_block_till_done()
 
     assert manager.update_firmware.called
     manager.update_firmware.assert_called_once_with(
@@ -198,3 +201,51 @@ async def test_update_progress(hass, test_charger, mock_ws_start):
         state = hass.states.get(entity_id)
         assert state.attributes[ATTR_IN_PROGRESS] is True
         assert state.attributes[ATTR_UPDATE_PERCENTAGE] == 50
+
+
+async def test_update_polling(hass, test_charger, mock_ws_start):
+    """Test update progress polling loop."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
+    manager.update_firmware = AsyncMock()
+
+    entity_id = "update.openevse_update"
+
+    # Mock process_request to return ota_update=1 on first poll,
+    # then ota_update=0 on second poll
+    poll_count = 0
+    original_process_request = manager.process_request
+
+    async def mock_process_request(url, method="", data=None, rapi=None):
+        nonlocal poll_count
+        if "status" in url and method == "get":
+            poll_count += 1
+            if poll_count == 1:
+                return {"ota_update": 1, "ota_progress": 45}
+            else:
+                return {"ota_update": 0}
+        return await original_process_request(url, method, data, rapi)
+
+    manager.process_request = mock_process_request
+
+    with patch("custom_components.openevse.update.async_sleep") as mock_sleep:
+        await hass.services.async_call(
+            UPDATE_DOMAIN, "install", {"entity_id": entity_id}, blocking=True
+        )
+        # Give the background task time to run its iterations
+        for _ in range(50):
+            if poll_count == 2:
+                break
+            await asyncio.sleep(0.01)
+
+        assert poll_count == 2
+        assert mock_sleep.call_count == 2


### PR DESCRIPTION
## Description

This PR adds progress reporting features to the `update` platform using the `python-openevse-http` 0.4.1 library.
Specifically, it adds:
- `UpdateEntityFeature.PROGRESS` support to `OpenEVSEUpdateEntity`.
- `in_progress` and `update_percentage` properties to retrieve firmware update status.
- A background task `_async_poll_update_progress` that polls `/status` to track update progress since progress updates are not pushed over WebSockets.
- Fully formatted and passing tests checking attributes and update polling loop progression.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background progress polling added for firmware installations to provide continuous update status and improved visibility during installs.

* **Bug Fixes**
  * Polling now tolerates transient errors and device reboot/connectivity interruptions without disrupting the install flow.

* **Tests**
  * Added tests covering polling behavior, error handling, and final install state.

* **Chores**
  * Bumped bundled library dependency for OpenEVSE HTTP client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->