### PR TITLE
refactor: use aiohttp client explicitly

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from openevsehttp.__main__ import OpenEVSE
@@ -656,7 +657,12 @@ class OpenEVSEManager:
         self._host = config_entry.data.get(CONF_HOST)
         self._username = config_entry.data.get(CONF_USERNAME)
         self._password = config_entry.data.get(CONF_PASSWORD)
-        self.charger = OpenEVSE(self._host, user=self._username, pwd=self._password)
+        self.charger = OpenEVSE(
+            self._host,
+            user=self._username,
+            pwd=self._password,
+            session=async_get_clientsession(hass),
+        )
 
 
 class InvalidValueError(Exception):

--- a/custom_components/openevse/config_flow.py
+++ b/custom_components/openevse/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import (
     EntitySelector,
     EntitySelectorConfig,
@@ -68,14 +69,13 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data=self.discovery_info,
         )
 
-    @staticmethod
-    async def _async_try_connect_and_fetch(ip_address: str) -> dict[str, Any]:
+    async def _async_try_connect_and_fetch(self, ip_address: str) -> dict[str, Any]:
         """Try to connect."""
         _LOGGER.debug("[%s] config_flow _async_try_connect_and_fetch", ip_address)
 
         # Make connection with device
         # This is to test the connection and to get info for unique_id
-        charger = OpenEVSE(ip_address)
+        charger = OpenEVSE(ip_address, session=async_get_clientsession(self.hass))
 
         try:
             await charger.update()
@@ -142,6 +142,7 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_HOST],
                 user=user_input[CONF_USERNAME],
                 pwd=user_input[CONF_PASSWORD],
+                session=async_get_clientsession(self.hass),
             )
 
             try:
@@ -184,6 +185,7 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_HOST],
                 user=user_input[CONF_USERNAME],
                 pwd=user_input[CONF_PASSWORD],
+                session=async_get_clientsession(self.hass),
             )
 
             try:


### PR DESCRIPTION
## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

This changes the openevse code to explicitly pass a aiohttp client - this fixes some unnecessary redundancy within HA due to making extra http clients, and lets us simplify the underlying client library.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved connection management in the OpenEVSE integration for more efficient resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->