### PR TITLE
feat: push vehicle SoC/range/ETA + home battery from HA sensors to the charger

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -33,10 +33,15 @@ from openevsehttp.exceptions import MissingSerial, UnsupportedFeature
 from .const import (
     BINARY_SENSORS,
     CONF_GRID,
+    CONF_HOME_BATTERY_POWER,
+    CONF_HOME_BATTERY_SOC,
     CONF_INVERT,
     CONF_NAME,
     CONF_SHAPER,
     CONF_SOLAR,
+    CONF_VEHICLE_ETA,
+    CONF_VEHICLE_RANGE,
+    CONF_VEHICLE_SOC,
     CONF_VOLTAGE,
     CONNECTION_ERROR,
     CONNECTION_ERRORS,
@@ -89,6 +94,11 @@ async def handle_state_change(
     solar_sensor = options.get(CONF_SOLAR)
     voltage_sensor = options.get(CONF_VOLTAGE)
     shaper_sensor = options.get(CONF_SHAPER)
+    vehicle_soc_sensor = options.get(CONF_VEHICLE_SOC)
+    vehicle_range_sensor = options.get(CONF_VEHICLE_RANGE)
+    vehicle_eta_sensor = options.get(CONF_VEHICLE_ETA)
+    home_battery_soc_sensor = options.get(CONF_HOME_BATTERY_SOC)
+    home_battery_power_sensor = options.get(CONF_HOME_BATTERY_POWER)
     changed_entity = event.data["entity_id"]
 
     if grid_sensor is not None and changed_entity == grid_sensor:
@@ -160,6 +170,118 @@ async def handle_state_change(
         logger.debug("Sending sensor data to OpenEVSE: (shaper: %s)", power)
         try:
             await manager.set_shaper_live_pwr(power=power)
+        except CONNECTION_ERRORS as err:
+            logger.warning(CONNECTION_ERROR, err)
+
+    if vehicle_soc_sensor is not None and changed_entity == vehicle_soc_sensor:
+        state = hass.states.get(vehicle_soc_sensor)
+        soc = state.state if state else None
+        if soc in [None, "unavailable", "unknown", ""]:
+            soc = None
+        else:
+            try:
+                soc = round(float(soc))
+            except (ValueError, TypeError):
+                logger.warning("Non-numeric state for vehicle SoC sensor: %s", soc)
+                soc = None
+
+        logger.debug("Sending sensor data to OpenEVSE: (vehicle_soc: %s)", soc)
+        try:
+            await manager.soc(battery_level=soc)
+        except UnsupportedFeature:
+            logger.debug("Vehicle SoC push not supported by firmware.")
+        except CONNECTION_ERRORS as err:
+            logger.warning(CONNECTION_ERROR, err)
+
+    if vehicle_range_sensor is not None and changed_entity == vehicle_range_sensor:
+        state = hass.states.get(vehicle_range_sensor)
+        vrange = state.state if state else None
+        if vrange in [None, "unavailable", "unknown", ""]:
+            vrange = None
+        else:
+            try:
+                vrange = round(float(vrange))
+            except (ValueError, TypeError):
+                logger.warning("Non-numeric state for vehicle range sensor: %s", vrange)
+                vrange = None
+
+        logger.debug("Sending sensor data to OpenEVSE: (vehicle_range: %s)", vrange)
+        try:
+            await manager.soc(battery_range=vrange)
+        except UnsupportedFeature:
+            logger.debug("Vehicle range push not supported by firmware.")
+        except CONNECTION_ERRORS as err:
+            logger.warning(CONNECTION_ERROR, err)
+
+    if vehicle_eta_sensor is not None and changed_entity == vehicle_eta_sensor:
+        state = hass.states.get(vehicle_eta_sensor)
+        eta = state.state if state else None
+        if eta in [None, "unavailable", "unknown", ""]:
+            eta = None
+        else:
+            try:
+                eta = round(float(eta))
+            except (ValueError, TypeError):
+                logger.warning("Non-numeric state for vehicle ETA sensor: %s", eta)
+                eta = None
+
+        logger.debug("Sending sensor data to OpenEVSE: (vehicle_eta: %s)", eta)
+        try:
+            await manager.soc(time_to_full=eta)
+        except UnsupportedFeature:
+            logger.debug("Vehicle ETA push not supported by firmware.")
+        except CONNECTION_ERRORS as err:
+            logger.warning(CONNECTION_ERROR, err)
+
+    if (
+        home_battery_soc_sensor is not None
+        and changed_entity == home_battery_soc_sensor
+    ):
+        state = hass.states.get(home_battery_soc_sensor)
+        hb_soc = state.state if state else None
+        if hb_soc in [None, "unavailable", "unknown", ""]:
+            hb_soc = None
+        else:
+            try:
+                hb_soc = round(float(hb_soc))
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Non-numeric state for home battery SoC sensor: %s", hb_soc
+                )
+                hb_soc = None
+
+        logger.debug("Sending sensor data to OpenEVSE: (home_battery_soc: %s)", hb_soc)
+        try:
+            await manager.home_battery(soc=hb_soc)
+        except UnsupportedFeature:
+            logger.debug("Home battery push not supported by firmware.")
+        except CONNECTION_ERRORS as err:
+            logger.warning(CONNECTION_ERROR, err)
+
+    if (
+        home_battery_power_sensor is not None
+        and changed_entity == home_battery_power_sensor
+    ):
+        state = hass.states.get(home_battery_power_sensor)
+        hb_power = state.state if state else None
+        if hb_power in [None, "unavailable", "unknown", ""]:
+            hb_power = None
+        else:
+            try:
+                hb_power = round(float(hb_power))
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Non-numeric state for home battery power sensor: %s", hb_power
+                )
+                hb_power = None
+
+        logger.debug(
+            "Sending sensor data to OpenEVSE: (home_battery_power: %s)", hb_power
+        )
+        try:
+            await manager.home_battery(power=hb_power)
+        except UnsupportedFeature:
+            logger.debug("Home battery push not supported by firmware.")
         except CONNECTION_ERRORS as err:
             logger.warning(CONNECTION_ERROR, err)
 
@@ -260,6 +382,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         sensors.append(options.get(CONF_VOLTAGE))
     if options.get(CONF_SHAPER):
         sensors.append(options.get(CONF_SHAPER))
+    if options.get(CONF_VEHICLE_SOC):
+        sensors.append(options.get(CONF_VEHICLE_SOC))
+    if options.get(CONF_VEHICLE_RANGE):
+        sensors.append(options.get(CONF_VEHICLE_RANGE))
+    if options.get(CONF_VEHICLE_ETA):
+        sensors.append(options.get(CONF_VEHICLE_ETA))
+    if options.get(CONF_HOME_BATTERY_SOC):
+        sensors.append(options.get(CONF_HOME_BATTERY_SOC))
+    if options.get(CONF_HOME_BATTERY_POWER):
+        sensors.append(options.get(CONF_HOME_BATTERY_POWER))
 
     if len(sensors) > 0:
         if hass.state == CoreState.running:

--- a/custom_components/openevse/config_flow.py
+++ b/custom_components/openevse/config_flow.py
@@ -20,11 +20,16 @@ from openevsehttp.__main__ import OpenEVSE
 
 from .const import (
     CONF_GRID,
+    CONF_HOME_BATTERY_POWER,
+    CONF_HOME_BATTERY_SOC,
     CONF_INVERT,
     CONF_NAME,
     CONF_SERIAL,
     CONF_SHAPER,
     CONF_SOLAR,
+    CONF_VEHICLE_ETA,
+    CONF_VEHICLE_RANGE,
+    CONF_VEHICLE_SOC,
     CONF_VOLTAGE,
     DEFAULT_HOST,
     DEFAULT_NAME,
@@ -264,6 +269,24 @@ class OpenEVSEOptionsFlowHandler(config_entries.OptionsFlow):
                     ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
                     vol.Optional(
                         CONF_SHAPER, default=options.get(CONF_SHAPER, "")
+                    ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
+                    vol.Optional(
+                        CONF_VEHICLE_SOC, default=options.get(CONF_VEHICLE_SOC, "")
+                    ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
+                    vol.Optional(
+                        CONF_VEHICLE_RANGE,
+                        default=options.get(CONF_VEHICLE_RANGE, ""),
+                    ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
+                    vol.Optional(
+                        CONF_VEHICLE_ETA, default=options.get(CONF_VEHICLE_ETA, "")
+                    ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
+                    vol.Optional(
+                        CONF_HOME_BATTERY_SOC,
+                        default=options.get(CONF_HOME_BATTERY_SOC, ""),
+                    ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
+                    vol.Optional(
+                        CONF_HOME_BATTERY_POWER,
+                        default=options.get(CONF_HOME_BATTERY_POWER, ""),
                     ): OptionalEntitySelector(EntitySelectorConfig(domain="sensor")),
                     vol.Optional(
                         CONF_INVERT, default=options.get(CONF_INVERT, False)

--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -51,10 +51,26 @@ CONF_SOLAR = "solar"
 CONF_INVERT = "invert_grid"
 CONF_VOLTAGE = "voltage"
 CONF_SHAPER = "shaper"
+CONF_VEHICLE_SOC = "vehicle_soc"
+CONF_VEHICLE_RANGE = "vehicle_range"
+CONF_VEHICLE_ETA = "vehicle_eta"
+CONF_HOME_BATTERY_SOC = "home_battery_soc"
+CONF_HOME_BATTERY_POWER = "home_battery_power"
 DEFAULT_HOST = "openevse.local"
 DEFAULT_NAME = "OpenEVSE"
 
-SENSOR_FIELDS = [CONF_GRID, CONF_SOLAR, CONF_VOLTAGE, CONF_SHAPER, CONF_INVERT]
+SENSOR_FIELDS = [
+    CONF_GRID,
+    CONF_SOLAR,
+    CONF_VOLTAGE,
+    CONF_SHAPER,
+    CONF_INVERT,
+    CONF_VEHICLE_SOC,
+    CONF_VEHICLE_RANGE,
+    CONF_VEHICLE_ETA,
+    CONF_HOME_BATTERY_SOC,
+    CONF_HOME_BATTERY_POWER,
+]
 
 # hass.data attributes
 UNSUB_LISTENERS = "unsub_listeners"

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==1.0.1"
+    "python-openevse-http==1.3.0"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/translations/en.json
+++ b/custom_components/openevse/translations/en.json
@@ -38,6 +38,11 @@
           "solar": "Solar production sensor (optional)",
           "voltage": "Grid voltage sensor (optional)",
           "shaper": "Shaper live power sensor (optional)",
+          "vehicle_soc": "Vehicle state of charge sensor (optional)",
+          "vehicle_range": "Vehicle range sensor (optional)",
+          "vehicle_eta": "Vehicle time-to-full-charge sensor (optional)",
+          "home_battery_soc": "Home battery state of charge sensor (optional)",
+          "home_battery_power": "Home battery power sensor (optional)",
           "invert_grid": "Invert grid import/export"
         },
         "description": "Configure sensor entities to push data to OpenEVSE.\n\nIMPORTANT NOTE: OpenEVSE expects positive import and negative export.",

--- a/custom_components/openevse/translations/es.json
+++ b/custom_components/openevse/translations/es.json
@@ -38,6 +38,11 @@
           "solar": "Sensor de producción solar (opcional)",
           "voltage": "Sensor de tensión de red (opcional)",
           "shaper": "Sensor de potencia en vivo del shaper (opcional)",
+          "vehicle_soc": "Sensor de estado de carga del vehículo (opcional)",
+          "vehicle_range": "Sensor de autonomía del vehículo (opcional)",
+          "vehicle_eta": "Sensor de tiempo hasta carga completa del vehículo (opcional)",
+          "home_battery_soc": "Sensor de estado de carga de la batería doméstica (opcional)",
+          "home_battery_power": "Sensor de potencia de la batería doméstica (opcional)",
           "invert_grid": "Importación/exportación de cuadrícula inversa"
         },
         "description": "Configure los sensores para enviar datos a OpenEVSE.\n\nNOTA IMPORTANTE: OpenEVSE espera una importación positiva y una exportación negativa.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==1.2.0
+python-openevse-http==1.3.0

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -436,6 +436,11 @@ async def test_options_flow(hass, test_charger, mock_ws_start):
         "solar": "",
         "voltage": "sensor.grid_voltage",
         "shaper": "sensor.shaper_power",
+        "vehicle_soc": "",
+        "vehicle_range": "",
+        "vehicle_eta": "",
+        "home_battery_soc": "",
+        "home_battery_power": "",
         "invert_grid": False,
     }
 
@@ -518,6 +523,11 @@ async def test_options_flow_all_empty_entities(hass, test_charger, mock_ws_start
         "solar": "",
         "voltage": "",
         "shaper": "",
+        "vehicle_soc": "",
+        "vehicle_range": "",
+        "vehicle_eta": "",
+        "home_battery_soc": "",
+        "home_battery_power": "",
         "invert_grid": False,
     }
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState
 from homeassistant.helpers.update_coordinator import UpdateFailed
-from openevsehttp.exceptions import MissingSerial
+from openevsehttp.exceptions import MissingSerial, UnsupportedFeature
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openevse import (
@@ -1140,6 +1140,58 @@ async def test_setup_entry_state_change_vehicle(
     await hass.async_block_till_done()
     assert "Non-numeric state for vehicle SoC sensor: invalid" in caplog.text
 
+    caplog.clear()
+    hass.states.async_set(range_entity, "invalid")
+    await hass.async_block_till_done()
+    assert "Non-numeric state for vehicle range sensor: invalid" in caplog.text
+
+    caplog.clear()
+    hass.states.async_set(eta_entity, "invalid")
+    await hass.async_block_till_done()
+    assert "Non-numeric state for vehicle ETA sensor: invalid" in caplog.text
+
+    # unavailable/unknown/empty states -> None sent (no warning)
+    caplog.clear()
+    hass.states.async_set(soc_entity, "unknown")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_soc: None)" in caplog.text
+
+    caplog.clear()
+    hass.states.async_set(range_entity, "unavailable")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_range: None)" in caplog.text
+
+    caplog.clear()
+    hass.states.async_set(eta_entity, "")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_eta: None)" in caplog.text
+
+    # firmware that doesn't support the push -> debug logged, no crash
+    caplog.clear()
+    with patch(
+        "custom_components.openevse.OpenEVSE.soc",
+        side_effect=UnsupportedFeature,
+    ):
+        hass.states.async_set(soc_entity, "55")
+        hass.states.async_set(range_entity, "210")
+        hass.states.async_set(eta_entity, "900")
+        await hass.async_block_till_done()
+    assert "Vehicle SoC push not supported by firmware." in caplog.text
+    assert "Vehicle range push not supported by firmware." in caplog.text
+    assert "Vehicle ETA push not supported by firmware." in caplog.text
+
+    # connection error on push -> warning logged, no crash
+    caplog.clear()
+    with patch(
+        "custom_components.openevse.OpenEVSE.soc",
+        side_effect=TimeoutError,
+    ):
+        hass.states.async_set(soc_entity, "56")
+        hass.states.async_set(range_entity, "211")
+        hass.states.async_set(eta_entity, "901")
+        await hass.async_block_till_done()
+    assert "Error connecting to device:" in caplog.text
+
 
 async def test_setup_entry_state_change_home_battery(
     hass, test_charger, mock_ws_start, caplog
@@ -1182,3 +1234,41 @@ async def test_setup_entry_state_change_home_battery(
     hass.states.async_set(soc_entity, "invalid")
     await hass.async_block_till_done()
     assert "Non-numeric state for home battery SoC sensor: invalid" in caplog.text
+
+    caplog.clear()
+    hass.states.async_set(power_entity, "invalid")
+    await hass.async_block_till_done()
+    assert "Non-numeric state for home battery power sensor: invalid" in caplog.text
+
+    # unavailable/empty states -> None sent (no warning)
+    caplog.clear()
+    hass.states.async_set(soc_entity, "unavailable")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (home_battery_soc: None)" in caplog.text
+
+    caplog.clear()
+    hass.states.async_set(power_entity, "unknown")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (home_battery_power: None)" in caplog.text
+
+    # firmware that doesn't support the push -> debug logged, no crash
+    caplog.clear()
+    with patch(
+        "custom_components.openevse.OpenEVSE.home_battery",
+        side_effect=UnsupportedFeature,
+    ):
+        hass.states.async_set(soc_entity, "70")
+        hass.states.async_set(power_entity, "-500")
+        await hass.async_block_till_done()
+    assert "Home battery push not supported by firmware." in caplog.text
+
+    # connection error on push -> warning logged, no crash
+    caplog.clear()
+    with patch(
+        "custom_components.openevse.OpenEVSE.home_battery",
+        side_effect=TimeoutError,
+    ):
+        hass.states.async_set(soc_entity, "71")
+        hass.states.async_set(power_entity, "-501")
+        await hass.async_block_till_done()
+    assert "Error connecting to device:" in caplog.text

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1089,3 +1089,96 @@ async def test_websocket_unexpected_error(
     assert "Unexpected error parsing sensors" in caplog.text
     # Verify traceback IS present for unexpected exceptions
     assert "Traceback" in caplog.text
+
+
+async def test_setup_entry_state_change_vehicle(
+    hass, test_charger, mock_ws_start, caplog
+):
+    """Test state changes push vehicle SoC/range/ETA to the charger."""
+    soc_entity = "sensor.vehicle_soc"
+    range_entity = "sensor.vehicle_range"
+    eta_entity = "sensor.vehicle_eta"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+        options={
+            "vehicle_soc": soc_entity,
+            "vehicle_range": range_entity,
+            "vehicle_eta": eta_entity,
+        },
+        version=2,
+    )
+    # seed initial states before setup so listeners attach
+    hass.states.async_set(soc_entity, "50")
+    hass.states.async_set(range_entity, "200")
+    hass.states.async_set(eta_entity, "3600")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    await hass.async_block_till_done()
+
+    hass.states.async_set(soc_entity, "75")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_soc: 75)" in caplog.text
+
+    hass.states.async_set(range_entity, "240")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_range: 240)" in caplog.text
+
+    hass.states.async_set(eta_entity, "1800")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (vehicle_eta: 1800)" in caplog.text
+
+    # non-numeric value -> warning logged and None sent
+    caplog.clear()
+    hass.states.async_set(soc_entity, "invalid")
+    await hass.async_block_till_done()
+    assert "Non-numeric state for vehicle SoC sensor: invalid" in caplog.text
+
+
+async def test_setup_entry_state_change_home_battery(
+    hass, test_charger, mock_ws_start, caplog
+):
+    """Test state changes push home battery SoC/power to the charger."""
+    soc_entity = "sensor.home_battery_soc"
+    power_entity = "sensor.home_battery_power"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+        options={
+            "home_battery_soc": soc_entity,
+            "home_battery_power": power_entity,
+        },
+        version=2,
+    )
+    # seed initial states before setup so listeners attach
+    hass.states.async_set(soc_entity, "60")
+    hass.states.async_set(power_entity, "0")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    await hass.async_block_till_done()
+
+    hass.states.async_set(soc_entity, "82")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (home_battery_soc: 82)" in caplog.text
+
+    hass.states.async_set(power_entity, "-1500")
+    await hass.async_block_till_done()
+    assert "Sending sensor data to OpenEVSE: (home_battery_power: -1500)" in caplog.text
+
+    # non-numeric value -> warning logged and None sent
+    caplog.clear()
+    hass.states.async_set(soc_entity, "invalid")
+    await hass.async_block_till_done()
+    assert "Non-numeric state for home battery SoC sensor: invalid" in caplog.text


### PR DESCRIPTION
## Summary

Lets users map Home Assistant sensors that get **pushed to the charger** via `python-openevse-http`'s `POST /status` API (same pattern as the existing solar/grid/voltage/shaper push):

- **Vehicle:** `vehicle_soc` / `vehicle_range` / `vehicle_eta` → `manager.soc(...)`
- **Home battery:** `home_battery_soc` / `home_battery_power` → `manager.home_battery(...)`

Five new `CONF_*` keys + `SENSOR_FIELDS` entries, options-flow entity selectors, `handle_state_change` listener blocks, en/es translations, and tests.

## Status: draft — depends on a lib release

- The **vehicle** half works against the already-released lib (`soc()` has shipped since 1.0.0).
- The **home battery** half calls `manager.home_battery(...)`, added in firstof9/python-openevse-http#617. Once that merges and a release is cut, `manifest.json` needs bumping to that version. Marking this draft until then so CI/runtime have the method.

Happy to split the vehicle-only half into a ready-to-merge PR if you'd prefer to land that first.

## Testing

- Full suite green locally against the branch + the updated lib: `107 passed`.
- Tests cover the config-flow expected dicts and the push round-trip for both vehicle and home-battery in `test_init`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for vehicle sensor tracking: state of charge, remaining range, and time-to-full
  * Added support for home battery monitoring: state of charge and power output

* **Bug Fixes**
  * Fixed syntax error in vehicle ETA configuration

* **Chores**
  * Updated underlying library dependency to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->