### PR TITLE
feat: add SSL and Verify SSL Certificate options to config flow

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -12,7 +12,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
+    CONF_SSL,
     CONF_USERNAME,
+    CONF_VERIFY_SSL,
     EVENT_HOMEASSISTANT_STARTED,
 )
 from homeassistant.core import (
@@ -799,10 +801,14 @@ class OpenEVSEManager:
         self._host = config_entry.data.get(CONF_HOST)
         self._username = config_entry.data.get(CONF_USERNAME)
         self._password = config_entry.data.get(CONF_PASSWORD)
+        self._ssl = config_entry.data.get(CONF_SSL, False)
+        self._ssl_verify = config_entry.data.get(CONF_VERIFY_SSL, True)
         self.charger = OpenEVSE(
             self._host,
             user=self._username,
             pwd=self._password,
+            ssl=self._ssl,
+            ssl_verify=self._ssl_verify,
             session=async_get_clientsession(hass),
         )
 

--- a/custom_components/openevse/config_flow.py
+++ b/custom_components/openevse/config_flow.py
@@ -9,7 +9,13 @@ from typing import Any, Final
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -149,6 +155,8 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_HOST],
                 user=user_input[CONF_USERNAME],
                 pwd=user_input[CONF_PASSWORD],
+                ssl=user_input.get(CONF_SSL, False),
+                ssl_verify=user_input.get(CONF_VERIFY_SSL, True),
                 session=async_get_clientsession(self.hass),
             )
 
@@ -194,6 +202,8 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_HOST],
                 user=user_input[CONF_USERNAME],
                 pwd=user_input[CONF_PASSWORD],
+                ssl=user_input.get(CONF_SSL, False),
+                ssl_verify=user_input.get(CONF_VERIFY_SSL, True),
                 session=async_get_clientsession(self.hass),
             )
 
@@ -250,6 +260,8 @@ class OpenEVSEFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._data[CONF_HOST],
                 user=user_input[CONF_USERNAME],
                 pwd=user_input[CONF_PASSWORD],
+                ssl=self._data.get(CONF_SSL, False),
+                ssl_verify=self._data.get(CONF_VERIFY_SSL, True),
                 session=async_get_clientsession(self.hass),
             )
 
@@ -389,5 +401,9 @@ def _get_schema(
             vol.Optional(
                 CONF_PASSWORD, default=_get_default(CONF_PASSWORD, "")
             ): cv.string,
+            vol.Optional(CONF_SSL, default=_get_default(CONF_SSL, False)): bool,
+            vol.Optional(
+                CONF_VERIFY_SSL, default=_get_default(CONF_VERIFY_SSL, True)
+            ): bool,
         },
     )

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==1.3.0"
+    "python-openevse-http==1.4.0"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/translations/en.json
+++ b/custom_components/openevse/translations/en.json
@@ -10,7 +10,9 @@
           "name": "Alias",
           "host": "Hostname/IP",
           "password": "Password (optional)",
-          "username": "Username (optional)"
+          "username": "Username (optional)",
+          "ssl": "Use SSL",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "description": "Please enter the connection information of OpenEVSE charger.",
         "title": "OpenEVSE Setup"
@@ -20,7 +22,9 @@
           "name": "Alias",
           "host": "Hostname/IP",
           "password": "Password (optional)",
-          "username": "Username (optional)"
+          "username": "Username (optional)",
+          "ssl": "Use SSL",
+          "verify_ssl": "Verify SSL Certificate"
         },
         "description": "Please enter the connection information of OpenEVSE charger.",
         "title": "OpenEVSE Setup"

--- a/custom_components/openevse/translations/es.json
+++ b/custom_components/openevse/translations/es.json
@@ -10,7 +10,9 @@
           "name": "Alias",
           "host": "Hostname/IP",
           "password": "Contraseña (opcional)",
-          "username": "Usuario (opcional)"
+          "username": "Usuario (opcional)",
+          "ssl": "Usar SSL",
+          "verify_ssl": "Verificar certificado SSL"
         },
         "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.",
         "title": "Configuración OpenEVSE"
@@ -20,7 +22,9 @@
           "name": "Alias",
           "host": "Hostname/IP",
           "password": "Contraseña (opcional)",
-          "username": "Usuario (opcional)"
+          "username": "Usuario (opcional)",
+          "ssl": "Usar SSL",
+          "verify_ssl": "Verificar certificado SSL"
         },
         "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.",
         "title": "Configuración OpenEVSE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==1.3.0
+python-openevse-http==1.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,8 +107,20 @@ def test_charger(mock_aioclient):
         body=load_fixture("status.json"),
         repeat=True,
     )
+    mock_aioclient.get(
+        TEST_URL_STATUS.replace("http://", "https://"),
+        status=200,
+        body=load_fixture("status.json"),
+        repeat=True,
+    )
     mock_aioclient.post(
         TEST_URL_STATUS,
+        status=200,
+        body='{ "msg": "OK" }',
+        repeat=True,
+    )
+    mock_aioclient.post(
+        TEST_URL_STATUS.replace("http://", "https://"),
         status=200,
         body='{ "msg": "OK" }',
         repeat=True,
@@ -120,7 +132,19 @@ def test_charger(mock_aioclient):
         repeat=True,
     )
     mock_aioclient.get(
+        TEST_URL_CONFIG.replace("http://", "https://"),
+        status=200,
+        body=load_fixture("config.json"),
+        repeat=True,
+    )
+    mock_aioclient.get(
         TEST_URL_WS,
+        status=101,
+        body=load_fixture("status.json"),
+        repeat=True,
+    )
+    mock_aioclient.get(
+        TEST_URL_WS.replace("ws://", "wss://"),
         status=101,
         body=load_fixture("status.json"),
         repeat=True,
@@ -132,8 +156,20 @@ def test_charger(mock_aioclient):
         body='{ "msg": "OK" }',
         repeat=True,
     )
+    mock_aioclient.post(
+        TEST_URL_OVERRIDE.replace("http://", "https://"),
+        status=200,
+        body='{ "msg": "OK" }',
+        repeat=True,
+    )
     mock_aioclient.patch(
         TEST_URL_OVERRIDE,
+        status=200,
+        body='{ "msg": "OK" }',
+        repeat=True,
+    )
+    mock_aioclient.patch(
+        TEST_URL_OVERRIDE.replace("http://", "https://"),
         status=200,
         body='{ "msg": "OK" }',
         repeat=True,
@@ -145,7 +181,19 @@ def test_charger(mock_aioclient):
         repeat=True,
     )
     mock_aioclient.get(
+        TEST_URL_OVERRIDE.replace("http://", "https://"),
+        status=200,
+        body="{}",
+        repeat=True,
+    )
+    mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
+        status=200,
+        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
+        repeat=True,
+    )
+    mock_aioclient.get(
+        TEST_URL_CLAIMS_TARGET.replace("http://", "https://"),
         status=200,
         body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
         repeat=True,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test config flow."""
 
 from ipaddress import ip_address
-from unittest.mock import patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 from homeassistant import config_entries, setup
@@ -36,6 +36,28 @@ pytestmark = pytest.mark.asyncio
                 "host": "openevse.test.tld",
                 "username": "",
                 "password": "",
+                "ssl": False,
+                "verify_ssl": True,
+            },
+        ),
+        (
+            {
+                "name": "OpenEVSE Charger SSL",
+                "host": "openevse.test.tld",
+                "username": "",
+                "password": "",
+                "ssl": True,
+                "verify_ssl": False,
+            },
+            "user",
+            "OpenEVSE Charger SSL",
+            {
+                "name": "OpenEVSE Charger SSL",
+                "host": "openevse.test.tld",
+                "username": "",
+                "password": "",
+                "ssl": True,
+                "verify_ssl": False,
             },
         ),
     ],
@@ -137,6 +159,28 @@ async def test_form_user_connection_error(
                 "host": "openevse.test.tld",
                 "username": "",
                 "password": "",
+                "ssl": False,
+                "verify_ssl": True,
+            },
+        ),
+        (
+            {
+                "name": "OpenEVSE Charger",
+                "host": "openevse.test.tld",
+                "username": "",
+                "password": "",
+                "ssl": True,
+                "verify_ssl": False,
+            },
+            "reconfigure",
+            "openevse",
+            {
+                "name": "OpenEVSE Charger",
+                "host": "openevse.test.tld",
+                "username": "",
+                "password": "",
+                "ssl": True,
+                "verify_ssl": False,
             },
         ),
     ],
@@ -745,3 +789,65 @@ async def test_reauth_flow_errors(hass, test_charger, mock_ws_start):
 
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "communication"}
+
+
+async def test_reauth_flow_ssl(hass, test_charger, mock_ws_start):
+    """Test reauth flow works successfully with SSL configured."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data={**CONFIG_DATA, "ssl": True, "verify_ssl": False},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Trigger reauth step
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": entry.entry_id,
+        },
+        data=entry.data,
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    # Submit correct/new credentials
+    with (
+        patch("custom_components.openevse.config_flow.OpenEVSE") as mock_openevse,
+        patch("custom_components.openevse.OpenEVSE.ws_disconnect", return_value=True),
+    ):
+        # We need update to return True on the mocked instance
+        mock_instance = mock_openevse.return_value
+        mock_instance.update = AsyncMock(return_value=True)
+        mock_instance.ws_disconnect = AsyncMock(return_value=True)
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "username": "new_user",
+                "password": "new_password",
+            },
+        )
+
+        mock_openevse.assert_called_once_with(
+            "openevse.test.tld",
+            user="new_user",
+            pwd="new_password",
+            ssl=True,
+            ssl_verify=False,
+            session=ANY,
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    await hass.async_block_till_done()
+
+    assert entry.data["username"] == "new_user"
+    assert entry.data["password"] == "new_password"
+    assert entry.data["ssl"] is True
+    assert entry.data["verify_ssl"] is False


### PR DESCRIPTION
## Description

Adds configuration options for the library's new SSL support to toggle SSL and Verify SSL Certificate during config flow, reconfigure, and reauth steps. Bumps python-openevse-http requirement to 1.4.0.

Fixes N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSL/TLS configuration support enabling secure connections during initial setup and reconfiguration workflows.
  * Added SSL certificate verification option to validate server certificates when using secure connections.
  * Updated integration dependency to support new SSL functionality.

* **Documentation**
  * Updated setup and reconfiguration interface translations (English, Spanish) for new SSL options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->