### PR TITLE
docs: add note about HTTPS certificate requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ Alternatively, add it manually within HACS:
 3. If not, click **+ Add Integration** in the bottom right, search for **OpenEVSE**, and select it.
 4. Enter the charger's **Host/IP address** (default: `openevse.local`), and optional **Username** and **Password** if your charger requires authentication.
 
+> [!NOTE]
+> If configuring the integration to use **HTTPS / SSL**, certificate files must be uploaded to the OpenEVSE device first.
+
+
 ### Advanced Options (Integration Configuration)
 To unlock smart features like **Solar PV Divert** and **Current Shaper**, you must bind external sensors.
 1. Go to **Settings** -> **Devices & Services** -> **OpenEVSE**.

--- a/custom_components/openevse/translations/en.json
+++ b/custom_components/openevse/translations/en.json
@@ -14,7 +14,7 @@
           "ssl": "Use SSL",
           "verify_ssl": "Verify SSL Certificate"
         },
-        "description": "Please enter the connection information of OpenEVSE charger.",
+        "description": "Please enter the connection information of OpenEVSE charger.\n\nNote: Certificates must be uploaded to the device before being able to use HTTPS.",
         "title": "OpenEVSE Setup"
       },
       "reconfigure": {
@@ -26,7 +26,7 @@
           "ssl": "Use SSL",
           "verify_ssl": "Verify SSL Certificate"
         },
-        "description": "Please enter the connection information of OpenEVSE charger.",
+        "description": "Please enter the connection information of OpenEVSE charger.\n\nNote: Certificates must be uploaded to the device before being able to use HTTPS.",
         "title": "OpenEVSE Setup"
       },
       "discovery_confirm": {

--- a/custom_components/openevse/translations/es.json
+++ b/custom_components/openevse/translations/es.json
@@ -14,7 +14,7 @@
           "ssl": "Usar SSL",
           "verify_ssl": "Verificar certificado SSL"
         },
-        "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.",
+        "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.\n\nNota: Los certificados deben subirse al dispositivo antes de poder utilizar HTTPS.",
         "title": "Configuración OpenEVSE"
       },
       "reconfigure": {
@@ -26,7 +26,7 @@
           "ssl": "Usar SSL",
           "verify_ssl": "Verificar certificado SSL"
         },
-        "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.",
+        "description": "Por favor, introduce la información de conexión al cargador OpenEVSE.\n\nNota: Los certificados deben subirse al dispositivo antes de poder utilizar HTTPS.",
         "title": "Configuración OpenEVSE"
       },
       "discovery_confirm": {


### PR DESCRIPTION
## Description

Adds a note to the README and configuration flow setup descriptions explaining that certificates must be uploaded to the OpenEVSE device before configuring it to use HTTPS / SSL.

Fixes N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality / Refactoring
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules