### PR TITLE
feat(sensor): support dynamic units using vehicle_range_with_unit

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -680,6 +680,8 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
             if skip_async and getattr(descriptor, "is_async_value", False):
                 continue
             sensor_property = descriptor.key
+            if sensor_property == "vehicle_range":
+                sensor_property = "vehicle_range_with_unit"
             if sensor_property not in manager_dir:
                 self.logger.debug("Could not update status for %s", key)
                 continue
@@ -760,6 +762,8 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         data.update(self._collect_values(SELECT_TYPES, "select"))
         data.update(self._collect_values(NUMBER_TYPES, "number"))
         data.update(self._collect_values(LIGHT_TYPES, "light"))
+        if "vehicle_range" in data and isinstance(data["vehicle_range"], tuple):
+            data["vehicle_range"] = data["vehicle_range"][0]
         self.logger.debug("Parsed data: %s", data)
         return data
 
@@ -776,6 +780,8 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         data.update(
             await self._collect_async_values(SENSOR_TYPES, "sensor", seen_results)
         )
+        if "vehicle_range" in data and isinstance(data["vehicle_range"], tuple):
+            data["vehicle_range"] = data["vehicle_range"][0]
         self.logger.debug("Parsed async data: %s", data)
         return data
 

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -93,7 +93,7 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
                 unit = range_data[1]
                 if unit == "miles":
                     return UnitOfLength.MILES
-                if unit == "km":
+                if unit in ("km", "kilometers"):
                     return UnitOfLength.KILOMETERS
         return self.entity_description.native_unit_of_measurement
 

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -93,7 +93,8 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
                 unit = range_data[1]
                 if unit == "miles":
                     return UnitOfLength.MILES
-                return UnitOfLength.KILOMETERS
+                if unit == "km":
+                    return UnitOfLength.KILOMETERS
         return self.entity_description.native_unit_of_measurement
 
     @property

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfLength
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_NAME, COORDINATOR, DOMAIN, MANAGER, SENSOR_TYPES
@@ -81,6 +82,19 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
     def native_value(self) -> Any:
         """Return the state of the sensor."""
         return self.coordinator.data.get(self._type)
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        """Return the unit of measurement."""
+        if self._type == "vehicle_range":
+            manager = self.hass.data[DOMAIN][self._unique_id][MANAGER]
+            range_data = getattr(manager, "vehicle_range_with_unit", None)
+            if range_data is not None:
+                unit = range_data[1]
+                if unit == "miles":
+                    return UnitOfLength.MILES
+                return UnitOfLength.KILOMETERS
+        return self.entity_description.native_unit_of_measurement
 
     @property
     def icon(self) -> str | None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==1.4.0
+python-openevse-http==1.5.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -411,3 +411,51 @@ async def test_vehicle_range_sensor_miles(
         ):
             res = await coordinator.async_parse_sensors()
             assert res["vehicle_range"] == 100
+
+
+async def test_vehicle_range_sensor_km(
+    hass,
+    test_charger,
+    mock_ws_start,
+    mock_aioclient,
+    entity_registry: er.EntityRegistry,
+):
+    """Test vehicle range sensor with km and kilometers unit mapping."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.openevse.OpenEVSE.vehicle_range_with_unit",
+        new_callable=PropertyMock,
+        return_value=(240, "km"),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_id = "sensor.openevse_vehicle_range"
+        entity_entry = entity_registry.async_get(entity_id)
+        assert entity_entry
+        entity_registry.async_update_entity(entity_id, disabled_by=None)
+
+        assert await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+        await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+        await hass.async_block_till_done()
+
+        entity = hass.data["entity_components"]["sensor"].get_entity(entity_id)
+        assert entity
+        assert entity.native_unit_of_measurement == UnitOfLength.KILOMETERS
+
+    # Reload and test with "kilometers"
+    with patch(
+        "custom_components.openevse.OpenEVSE.vehicle_range_with_unit",
+        new_callable=PropertyMock,
+        return_value=(240, "kilometers"),
+    ):
+        # Trigger dynamic update check
+        entity = hass.data["entity_components"]["sensor"].get_entity(entity_id)
+        assert entity
+        assert entity.native_unit_of_measurement == UnitOfLength.KILOMETERS

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,11 +3,12 @@
 import contextlib
 import logging
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from aiohttp import ClientError
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import UnitOfLength
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -361,3 +362,52 @@ async def test_sensor_availability_aioclient(
 
     state = hass.states.get("sensor.openevse_charging_status")
     assert state.state != "unavailable"
+
+
+async def test_vehicle_range_sensor_miles(
+    hass,
+    test_charger,
+    mock_ws_start,
+    mock_aioclient,
+    entity_registry: er.EntityRegistry,
+):
+    """Test vehicle range sensor with miles unit and async parsing logic."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.openevse.OpenEVSE.vehicle_range_with_unit",
+        new_callable=PropertyMock,
+        return_value=(150, "miles"),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Enable vehicle range sensor (disabled by default)
+        entity_id = "sensor.openevse_vehicle_range"
+        entity_entry = entity_registry.async_get(entity_id)
+        assert entity_entry
+        entity_registry.async_update_entity(entity_id, disabled_by=None)
+
+        # reload the integration sensor platform
+        assert await hass.config_entries.async_forward_entry_unload(entry, "sensor")
+        await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+        await hass.async_block_till_done()
+
+        entity = hass.data["entity_components"]["sensor"].get_entity(entity_id)
+        assert entity
+        assert entity.native_unit_of_measurement == UnitOfLength.MILES
+
+        # Test async_parse_sensors unpacking
+        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+        with patch.object(
+            coordinator,
+            "_collect_async_values",
+            return_value={"vehicle_range": (100, "miles")},
+        ):
+            res = await coordinator.async_parse_sensors()
+            assert res["vehicle_range"] == 100


### PR DESCRIPTION
## Description

This PR updates the OpenEVSE integration to utilize the new `vehicle_range_with_unit` method from `python-openevse-http` v1.5.0. This resolves the deprecation warning for the old `vehicle_range` property and adds support for dynamic units of measurement (miles vs. kilometers) for the vehicle range sensor depending on the device's configuration.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules