### PR TITLE
feat(switch): implement Vehicle Range Miles configuration option

### DIFF
--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -473,6 +473,12 @@ SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
     ),
+    "mqtt_vehicle_range_miles": OpenEVSESwitchEntityDescription(
+        name="Vehicle Range Miles",
+        key="mqtt_vehicle_range_miles",
+        toggle_command="set_mqtt_vehicle_range_miles",
+        device_class=SwitchDeviceClass.SWITCH,
+    ),
 }
 
 # Name, options, command, entity category
@@ -556,6 +562,12 @@ BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
     "shaper_updated": BinarySensorEntityDescription(
         name="Shaper Updated",
         key="shaper_updated",
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ),
+    "mqtt_vehicle_range_miles": BinarySensorEntityDescription(
+        name="Vehicle Range Miles",
+        key="mqtt_vehicle_range_miles",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ),

--- a/custom_components/openevse/switch.py
+++ b/custom_components/openevse/switch.py
@@ -115,6 +115,8 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
                 await self._manager.release_claim()
             elif self.toggle_command == "set_shaper":
                 await self._manager.set_shaper(True)
+            elif self.toggle_command == "set_mqtt_vehicle_range_miles":
+                await self._manager.set_mqtt_vehicle_range_miles(True)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:
@@ -133,6 +135,8 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
                 await self._manager.make_claim(state="active")
             elif self.toggle_command == "set_shaper":
                 await self._manager.set_shaper(False)
+            elif self.toggle_command == "set_mqtt_vehicle_range_miles":
+                await self._manager.set_mqtt_vehicle_range_miles(False)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==1.4.0
+python-openevse-http==1.5.0

--- a/tests/const.py
+++ b/tests/const.py
@@ -46,6 +46,7 @@ CHARGER_DATA = {
     "divert_active": False,
     "using_ethernet": False,
     "shaper_active": False,
+    "mqtt_vehicle_range_miles": False,
     "max_current_soft": 48,
     "led_brightness": 128,
 }
@@ -108,6 +109,7 @@ DIAG_DEVICE_RESULTS = {
     "max_current_soft": 28,
     "min_amps": 6,
     "mqtt_connected": True,
+    "mqtt_vehicle_range_miles": False,
     "openevse_firmware": "7.1.3",
     "ota_update": False,
     "override_state": "auto",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,7 +65,7 @@ async def test_setup_entry(hass, test_charger, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -86,7 +86,7 @@ async def test_setup_entry_bad_serial(hass, test_charger_bad_serial, mock_ws_sta
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -138,7 +138,7 @@ async def test_setup_entry_state_change(hass, test_charger, mock_ws_start, caplo
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -170,7 +170,7 @@ async def test_setup_entry_state_change_timeout(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -202,7 +202,7 @@ async def test_setup_entry_state_change_2(hass, test_charger, mock_ws_start, cap
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -239,7 +239,7 @@ async def test_setup_entry_state_change_2_bad_post(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -305,7 +305,7 @@ async def test_setup_entry_v2(hass, test_charger_v2, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -40,7 +40,7 @@ async def test_switches(
     await hass.async_block_till_done()
 
     # Ensure all switches are created
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
 
     # Get the coordinator to simulate data updates
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
@@ -175,6 +175,51 @@ async def test_switches(
     state = hass.states.get(entity_id)
     assert state.state == "on"
 
+    # -------------------------------------------------------------------------
+    # 5. Test Vehicle Range Miles Switch
+    # -------------------------------------------------------------------------
+    # Initial State: In CHARGER_DATA, "mqtt_vehicle_range_miles" is
+    # False, so switch is OFF.
+    entity_id = "switch.openevse_vehicle_range_miles"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "off"
+
+    # Action: Turn On
+    mock_aioclient.post(
+        "http://openevse.test.tld/config",
+        status=200,
+        body='{"msg": "OK"}',
+        repeat=True,
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["mqtt_vehicle_range_miles"] = True
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be ON
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+
+    # Action: Turn Off
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["mqtt_vehicle_range_miles"] = False
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be OFF
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+
 
 async def test_switches_v2(
     hass,
@@ -195,7 +240,7 @@ async def test_switches_v2(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
+        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
 


### PR DESCRIPTION
## Description

This PR implements the new `set_mqtt_vehicle_range_miles` configuration option from `python-openevse-http` v1.5.0 in the OpenEVSE integration as a Switch. It allows toggling whether the OpenEVSE device expects MQTT vehicle range updates in miles (On) or kilometers (Off).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added vehicle range miles switch entity to control and manage vehicle-specific range configuration
  * Added vehicle range miles diagnostic sensor to monitor vehicle metrics and provide system insights

* **Chores**
  * Updated core library dependency to the latest stable version for improved integration performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->