### PR TITLE
refactor: convert entity descriptions to tuples, support value_fn, and unify device_info

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -7,6 +7,7 @@ import functools
 import inspect
 import logging
 from datetime import timedelta
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -670,13 +671,19 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         new_data.update(await self.async_parse_sensors())
         self._data = new_data
 
+    def _normalize_descriptors(self, descriptors) -> list[tuple[str, Any]]:
+        """Normalize descriptors to a list of (key, descriptor) tuples."""
+        if isinstance(descriptors, dict):
+            return list(descriptors.items())
+        return [(desc.key, desc) for desc in descriptors]
+
     def _collect_values(
         self, descriptors, label, value_cast=None, skip_async=True
     ) -> dict:
         """Collect values from descriptors."""
         data = {}
         manager_dir = dir(self._manager)
-        for key, descriptor in descriptors.items():
+        for key, descriptor in self._normalize_descriptors(descriptors):
             if skip_async and getattr(descriptor, "is_async_value", False):
                 continue
             sensor_property = descriptor.key
@@ -711,7 +718,7 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         if seen_results is None:
             seen_results = {}
         manager_dir = dir(self._manager)
-        for key, descriptor in descriptors.items():
+        for key, descriptor in self._normalize_descriptors(descriptors):
             if not getattr(descriptor, "is_async_value", False):
                 continue
             sensor_property = descriptor.key

--- a/custom_components/openevse/binary_sensor.py
+++ b/custom_components/openevse/binary_sensor.py
@@ -53,11 +53,12 @@ class OpenEVSEBinarySensor(CoordinatorEntity, OpenEVSEEntity, BinarySensorEntity
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if the service is on."""
-        data = self.coordinator.data
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self.entity_description, "value_fn", None) is not None:
-            return cast(bool, self.entity_description.value_fn(data) == 1)
+            value = self.entity_description.value_fn(data)
+            return None if value is None else cast(bool, value == 1)
         if self._type not in data:
             self.coordinator.logger.info(
                 "binary_sensor [%s] not supported.", self._type

--- a/custom_components/openevse/binary_sensor.py
+++ b/custom_components/openevse/binary_sensor.py
@@ -5,7 +5,6 @@ from typing import cast
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
-    BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.update_coordinator import (
@@ -14,6 +13,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import BINARY_SENSORS, CONF_NAME, COORDINATOR, DOMAIN
+from .entity import OpenEVSEBinarySensorEntityDescription, OpenEVSEEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,20 +23,20 @@ async def async_setup_entry(hass, entry, async_add_devices):
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
 
     binary_sensors = []
-    for binary_sensor in BINARY_SENSORS:
-        binary_sensors.append(
-            OpenEVSEBinarySensor(BINARY_SENSORS[binary_sensor], coordinator, entry)
-        )
+    for description in BINARY_SENSORS:
+        binary_sensors.append(OpenEVSEBinarySensor(description, coordinator, entry))
 
     async_add_devices(binary_sensors, False)
 
 
-class OpenEVSEBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class OpenEVSEBinarySensor(CoordinatorEntity, OpenEVSEEntity, BinarySensorEntity):
     """Implementation of an OpenEVSE binary sensor."""
+
+    entity_description: OpenEVSEBinarySensorEntityDescription
 
     def __init__(
         self,
-        sensor_description: BinarySensorEntityDescription,
+        sensor_description: OpenEVSEBinarySensorEntityDescription,
         coordinator: DataUpdateCoordinator,
         config: ConfigEntry,
     ) -> None:
@@ -53,20 +53,11 @@ class OpenEVSEBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
 
     @property
-    def device_info(self) -> dict:
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._unique_id)},
-        }
-
-        return info
-
-    @property
     def is_on(self) -> bool:
         """Return True if the service is on."""
         data = self.coordinator.data
+        if getattr(self.entity_description, "value_fn", None) is not None:
+            return cast(bool, self.entity_description.value_fn(data) == 1)
         if self._type not in data:
             self.coordinator.logger.info(
                 "binary_sensor [%s] not supported.", self._type

--- a/custom_components/openevse/button.py
+++ b/custom_components/openevse/button.py
@@ -17,6 +17,7 @@ from .const import (
     DOMAIN,
     MANAGER,
 )
+from .entity import OpenEVSEEntity
 
 
 async def async_setup_entry(
@@ -29,14 +30,12 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     assert manager is not None
     buttons = []
-    for button in BUTTON_TYPES:
-        buttons.append(
-            OpenEVSEButton(BUTTON_TYPES[button], manager, config_entry, coordinator)
-        )
+    for description in BUTTON_TYPES:
+        buttons.append(OpenEVSEButton(description, manager, config_entry, coordinator))
     async_add_entities(buttons, False)
 
 
-class OpenEVSEButton(ButtonEntity):
+class OpenEVSEButton(OpenEVSEEntity, ButtonEntity):
     """OpenEVSE restart button."""
 
     def __init__(
@@ -50,23 +49,13 @@ class OpenEVSEButton(ButtonEntity):
         self.coordinator = coordinator
         self.entity_description = button_description
         self.config = config_entry
+        self._config = config_entry
         self.manager = manager
         self._key = button_description.key
         self._name = button_description.name
         self._base_unique_id = config_entry.entry_id
         self._attr_name = f"{config_entry.data[CONF_NAME]} {self._name}"
         self._attr_unique_id = f"{self._base_unique_id}.{self._key}"
-
-    @property
-    def device_info(self) -> dict:
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self.config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._base_unique_id)},
-        }
-
-        return info
 
     async def async_press(self) -> None:
         """Handle the button press."""

--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -8,7 +8,6 @@ from typing import Final
 import aiohttp
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
-    BinarySensorEntityDescription,
 )
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntityDescription
 from homeassistant.components.number import NumberDeviceClass, NumberMode
@@ -32,6 +31,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 
 from .entity import (
+    OpenEVSEBinarySensorEntityDescription,
     OpenEVSELightEntityDescription,
     OpenEVSENumberEntityDescription,
     OpenEVSESelectEntityDescription,
@@ -123,12 +123,20 @@ DIVERT_MODE = ["fast", "eco"]
 OVERRIDE_STATE = ["active", "auto", "disabled"]
 
 # Name, unit of measure, property, icon, device class, state class
-SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
-    "status": OpenEVSESensorEntityDescription(
-        key="status", name="Station Status", icon="mdi:ev-station"
+# Name, unit of measure, property, icon, device class, state class
+SENSOR_TYPES: Final[tuple[OpenEVSESensorEntityDescription, ...]] = (
+    OpenEVSESensorEntityDescription(
+        key="status",
+        name="Station Status",
+        icon="mdi:ev-station",
+        value_fn=lambda data: data.get("status"),
     ),
-    "state": OpenEVSESensorEntityDescription(key="state", name="Charging Status"),
-    "charge_time_elapsed": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
+        key="state",
+        name="Charging Status",
+        value_fn=lambda data: data.get("state"),
+    ),
+    OpenEVSESensorEntityDescription(
         key="charge_time_elapsed",
         name="Charge Time Elapsed",
         icon="mdi:camera-timer",
@@ -137,39 +145,44 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.DURATION,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("charge_time_elapsed"),
     ),
-    "ambient_temperature": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="ambient_temperature",
         name="Ambient Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
+        value_fn=lambda data: data.get("ambient_temperature"),
     ),
-    "ir_temperature": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="ir_temperature",
         name="IR Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("ir_temperature"),
     ),
-    "rtc_temperature": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="rtc_temperature",
         name="RTC Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("rtc_temperature"),
     ),
-    "esp_temperature": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="esp_temperature",
         name="ESP32 Temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("esp_temperature"),
     ),
-    "usage_session": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="usage_session",
         name="Usage this Session",
         native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
@@ -177,8 +190,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("usage_session"),
     ),
-    "usage_total": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="usage_total",
         name="Total Usage",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -186,21 +200,24 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.TOTAL_INCREASING,
         device_class=SensorDeviceClass.ENERGY,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("usage_total"),
     ),
-    "openevse_firmware": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="openevse_firmware",
         name="Controller Firmware",
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("openevse_firmware"),
     ),
-    "protocol_version": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="protocol_version",
         name="Protocol Version",
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("protocol_version"),
     ),
-    "charging_voltage": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="charging_voltage",
         name="Charging Voltage",
         icon="mdi:sine-wave",
@@ -208,8 +225,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.VOLTAGE,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("charging_voltage"),
     ),
-    "charging_current": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="charging_current",
         name="Charging Current",
         icon="mdi:sine-wave",
@@ -218,44 +236,50 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("charging_current"),
     ),
-    "service_level": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="service_level",
         name="Service Level",
         icon="mdi:leaf",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("service_level"),
     ),
-    "max_amps": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="max_amps",
         name="Max Amps",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("max_amps"),
     ),
-    "min_amps": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="min_amps",
         name="Min Amps",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("min_amps"),
     ),
-    "current_capacity": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="current_capacity",
         name="Current Capacity",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("current_capacity"),
     ),
-    "wifi_firmware": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="wifi_firmware",
         name="WiFi Firmware Version",
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("wifi_firmware"),
     ),
-    "charging_power": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="charging_power",
         name="Current Power Usage (Calculated)",
         icon="mdi:flash",
@@ -264,28 +288,32 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("charging_power"),
     ),
-    "wifi_signal": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="wifi_signal",
         name="WiFi Signal Strength",
         icon="mdi:wifi",
         native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("wifi_signal"),
     ),
-    "ammeter_scale_factor": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="ammeter_scale_factor",
         name="Sensor Scale",
         icon="mdi:scale",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("ammeter_scale_factor"),
     ),
-    "divertmode": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Divert Mode",
         key="divertmode",
         icon="mdi:solar-power",
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("divertmode"),
     ),
-    "available_current": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="PV Available Current",
         key="available_current",
         icon="mdi:sine-wave",
@@ -293,8 +321,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("available_current"),
     ),
-    "smoothed_available_current": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="PV Smoothed Available Current",
         key="smoothed_available_current",
         icon="mdi:sine-wave",
@@ -302,16 +331,18 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
         suggested_display_precision=1,
+        value_fn=lambda data: data.get("smoothed_available_current"),
     ),
-    "charge_rate": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="PV Charge Rate",
         key="charge_rate",
         icon="mdi:sine-wave",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.CURRENT,
+        value_fn=lambda data: data.get("charge_rate"),
     ),
-    "shaper_live_power": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Shaper Power",
         key="shaper_live_power",
         icon="mdi:flash",
@@ -320,8 +351,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("shaper_live_power"),
     ),
-    "shaper_available_current": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Shaper Current Available",
         key="shaper_available_current",
         icon="mdi:flash",
@@ -330,8 +362,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("shaper_available_current"),
     ),
-    "shaper_max_power": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Shaper Max Power",
         key="shaper_max_power",
         icon="mdi:flash",
@@ -339,8 +372,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("shaper_max_power"),
     ),
-    "vehicle_soc": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Vehicle Battery Level",
         key="vehicle_soc",
         icon="mdi:battery",
@@ -349,8 +383,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("vehicle_soc"),
     ),
-    "vehicle_range": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Vehicle Range",
         key="vehicle_range",
         icon="mdi:ev-station",
@@ -358,8 +393,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.DISTANCE,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("vehicle_range"),
     ),
-    "vehicle_eta": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         name="Vehicle Charge Completion",
         key="vehicle_eta",
         icon="mdi:car-electric",
@@ -367,8 +403,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("vehicle_eta"),
     ),
-    "total_day": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="total_day",
         name="Usage (Today)",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -377,8 +414,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_enabled_default=False,
         min_version="3.0.0",
+        value_fn=lambda data: data.get("total_day"),
     ),
-    "total_week": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="total_week",
         name="Usage (Week)",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -387,8 +425,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_enabled_default=False,
         min_version="3.0.0",
+        value_fn=lambda data: data.get("total_week"),
     ),
-    "total_month": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="total_month",
         name="Usage (Month)",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -397,8 +436,9 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_enabled_default=False,
         min_version="3.0.0",
+        value_fn=lambda data: data.get("total_month"),
     ),
-    "total_year": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="total_year",
         name="Usage (Year)",
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
@@ -407,24 +447,27 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         device_class=SensorDeviceClass.ENERGY,
         entity_registry_enabled_default=False,
         min_version="3.0.0",
+        value_fn=lambda data: data.get("total_year"),
     ),
-    "max_current": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="max_current",
         name="Max Current",
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda data: data.get("max_current"),
     ),
-    "override_state": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="override_state",
         name="Override State",
         entity_category=EntityCategory.DIAGNOSTIC,
         is_async_value=True,
         value="get_override_state",
         min_version="4.1.0",
+        value_fn=lambda data: data.get("override_state"),
     ),
-    "current_power": OpenEVSESensorEntityDescription(
+    OpenEVSESensorEntityDescription(
         key="current_power",
         name="Current Power Usage (Actual)",
         icon="mdi:flash",
@@ -433,57 +476,64 @@ SENSOR_TYPES: Final[dict[str, OpenEVSESensorEntityDescription]] = {
         state_class=SensorStateClass.MEASUREMENT,
         suggested_display_precision=1,
         min_version="4.2.2",
+        value_fn=lambda data: data.get("current_power"),
     ),
-}
+)
 
-SWITCH_TYPES: Final[dict[str, OpenEVSESwitchEntityDescription]] = {
-    "sleep_mode": OpenEVSESwitchEntityDescription(
+SWITCH_TYPES: Final[tuple[OpenEVSESwitchEntityDescription, ...]] = (
+    OpenEVSESwitchEntityDescription(
         name="Sleep Mode",
         key="state",
         toggle_command="toggle_override",
         device_class=SwitchDeviceClass.SWITCH,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("state"),
     ),
-    "sleep_mode_new": OpenEVSESwitchEntityDescription(
+    OpenEVSESwitchEntityDescription(
         name="Sleep Mode (new)",
         key="state",
         toggle_command="claim",
         device_class=SwitchDeviceClass.SWITCH,
         entity_registry_enabled_default=False,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("state"),
     ),
-    "manual_override": OpenEVSESwitchEntityDescription(
+    OpenEVSESwitchEntityDescription(
         name="Manual Override",
         key="manual_override",
         toggle_command="toggle_override",
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("manual_override"),
     ),
-    "divertmode": OpenEVSESwitchEntityDescription(
+    OpenEVSESwitchEntityDescription(
         name="Solar PV Divert",
         key="divert_active",
         toggle_command="divert_mode",
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("divert_active"),
     ),
-    "shaper": OpenEVSESwitchEntityDescription(
+    OpenEVSESwitchEntityDescription(
         name="Current Shaper",
         key="shaper_active",
         toggle_command="set_shaper",
         device_class=SwitchDeviceClass.SWITCH,
         min_version="4.1.0",
+        value_fn=lambda data: data.get("shaper_active"),
     ),
-    "mqtt_vehicle_range_miles": OpenEVSESwitchEntityDescription(
+    OpenEVSESwitchEntityDescription(
         name="Vehicle Range Miles",
         key="mqtt_vehicle_range_miles",
         toggle_command="set_mqtt_vehicle_range_miles",
         device_class=SwitchDeviceClass.SWITCH,
+        value_fn=lambda data: data.get("mqtt_vehicle_range_miles"),
     ),
-}
+)
 
 # Name, options, command, entity category
-SELECT_TYPES: Final[dict[str, OpenEVSESelectEntityDescription]] = {
-    "max_current_soft": OpenEVSESelectEntityDescription(
+SELECT_TYPES: Final[tuple[OpenEVSESelectEntityDescription, ...]] = (
+    OpenEVSESelectEntityDescription(
         name="Charge Rate",
         key="max_current_soft",
         default_options=None,
@@ -492,8 +542,9 @@ SELECT_TYPES: Final[dict[str, OpenEVSESelectEntityDescription]] = {
         entity_registry_enabled_default=False,
         is_async_value=True,
         value="get_charge_current",
+        value_fn=lambda data: data.get("max_current_soft"),
     ),
-    "override_state": OpenEVSESelectEntityDescription(
+    OpenEVSESelectEntityDescription(
         key="override_state",
         name="Override State",
         entity_category=EntityCategory.CONFIG,
@@ -501,95 +552,107 @@ SELECT_TYPES: Final[dict[str, OpenEVSESelectEntityDescription]] = {
         is_async_value=True,
         value="get_override_state",
         min_version="4.1.0",
+        value_fn=lambda data: data.get("override_state"),
     ),
-    "divertmode": OpenEVSESelectEntityDescription(
+    OpenEVSESelectEntityDescription(
         name="Divert Mode",
         key="divertmode",
         default_options=DIVERT_MODE,
         command="set_divert_mode",
+        value_fn=lambda data: data.get("divertmode"),
     ),
-}
+)
 
 # key: name
-BINARY_SENSORS: Final[dict[str, BinarySensorEntityDescription]] = {
-    "ota_update": BinarySensorEntityDescription(
+BINARY_SENSORS: Final[tuple[OpenEVSEBinarySensorEntityDescription, ...]] = (
+    OpenEVSEBinarySensorEntityDescription(
         name="OTA Update",
         key="ota_update",
         device_class=BinarySensorDeviceClass.UPDATE,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("ota_update"),
     ),
-    "vehicle": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Vehicle Connected",
         key="vehicle",
         device_class=BinarySensorDeviceClass.PLUG,
+        value_fn=lambda data: data.get("vehicle"),
     ),
-    "manual_override": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Manual Override",
         key="manual_override",
         device_class=BinarySensorDeviceClass.POWER,
+        value_fn=lambda data: data.get("manual_override"),
     ),
-    "divert_active": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Divert Active",
         key="divert_active",
         device_class=BinarySensorDeviceClass.POWER,
+        value_fn=lambda data: data.get("divert_active"),
     ),
-    "using_ethernet": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Ethernet Connected",
         key="using_ethernet",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("using_ethernet"),
     ),
-    "shaper_active": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Shaper Active",
         key="shaper_active",
         device_class=BinarySensorDeviceClass.POWER,
+        value_fn=lambda data: data.get("shaper_active"),
     ),
-    "has_limit": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Limit Active",
         key="has_limit",
         device_class=BinarySensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("has_limit"),
     ),
-    "mqtt_connected": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="MQTT Connected",
         key="mqtt_connected",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("mqtt_connected"),
     ),
-    "shaper_updated": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Shaper Updated",
         key="shaper_updated",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("shaper_updated"),
     ),
-    "mqtt_vehicle_range_miles": BinarySensorEntityDescription(
+    OpenEVSEBinarySensorEntityDescription(
         name="Vehicle Range Miles",
         key="mqtt_vehicle_range_miles",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        value_fn=lambda data: data.get("mqtt_vehicle_range_miles"),
     ),
-}
+)
 
-BUTTON_TYPES: Final[dict[str, ButtonEntityDescription]] = {
-    "restart_wifi": ButtonEntityDescription(
+BUTTON_TYPES: Final[tuple[ButtonEntityDescription, ...]] = (
+    ButtonEntityDescription(
         key="restart_wifi",
         name="Restart WiFi",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
     ),
-    "restart_evse": ButtonEntityDescription(
+    ButtonEntityDescription(
         key="restart_evse",
         name="Restart EVSE",
         device_class=ButtonDeviceClass.RESTART,
         entity_category=EntityCategory.CONFIG,
     ),
-}
+)
 
-NUMBER_TYPES: Final[dict[str, OpenEVSENumberEntityDescription]] = {
-    "max_current_soft": OpenEVSENumberEntityDescription(
+NUMBER_TYPES: Final[tuple[OpenEVSENumberEntityDescription, ...]] = (
+    OpenEVSENumberEntityDescription(
         name="Charge Rate",
         key="max_current_soft",
         default_options=None,
@@ -600,15 +663,17 @@ NUMBER_TYPES: Final[dict[str, OpenEVSENumberEntityDescription]] = {
         mode=NumberMode.AUTO,
         is_async_value=True,
         value="get_charge_current",
+        value_fn=lambda data: data.get("max_current_soft"),
     ),
-}
+)
 
-LIGHT_TYPES: Final[dict[str, OpenEVSELightEntityDescription]] = {
-    "led_brightness": OpenEVSELightEntityDescription(
+LIGHT_TYPES: Final[tuple[OpenEVSELightEntityDescription, ...]] = (
+    OpenEVSELightEntityDescription(
         key="led_brightness",
         name="LED Brightness",
         entity_category=EntityCategory.CONFIG,
         command="set_led_brightness",
         min_version="4.1.0",
+        value_fn=lambda data: data.get("led_brightness"),
     ),
-}
+)

--- a/custom_components/openevse/entity.py
+++ b/custom_components/openevse/entity.py
@@ -2,13 +2,31 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
+from homeassistant.components.binary_sensor import BinarySensorEntityDescription
 from homeassistant.components.light import LightEntityDescription
 from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.const import CONF_NAME
+from homeassistant.helpers.device_registry import DeviceInfo
+
+
+class OpenEVSEEntity:
+    """Base class for OpenEVSE entities."""
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return a port description for device registry."""
+        return DeviceInfo(
+            manufacturer="OpenEVSE",
+            name=self._config.data[CONF_NAME],
+            connections={("openevse", self._config.entry_id)},
+        )
 
 
 @dataclass
@@ -20,6 +38,7 @@ class OpenEVSESelectEntityDescription(SelectEntityDescription):
     is_async_value: bool | None = False
     value: str | None = None
     min_version: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
 
 
 @dataclass
@@ -28,6 +47,7 @@ class OpenEVSESwitchEntityDescription(SwitchEntityDescription):
 
     toggle_command: str | None = None
     min_version: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
 
 
 @dataclass
@@ -40,6 +60,7 @@ class OpenEVSENumberEntityDescription(NumberEntityDescription):
     max: int | None = None
     is_async_value: bool | None = False
     value: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
 
 
 @dataclass
@@ -48,6 +69,7 @@ class OpenEVSELightEntityDescription(LightEntityDescription):
 
     command: str | None = None
     min_version: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
 
 
 @dataclass
@@ -57,3 +79,14 @@ class OpenEVSESensorEntityDescription(SensorEntityDescription):
     is_async_value: bool | None = False
     value: str | None = None
     min_version: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None
+
+
+@dataclass
+class OpenEVSEBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Class describing OpenEVSE binary sensor entities."""
+
+    is_async_value: bool | None = False
+    value: str | None = None
+    min_version: str | None = None
+    value_fn: Callable[[dict[str, Any]], Any] | None = None

--- a/custom_components/openevse/entity.py
+++ b/custom_components/openevse/entity.py
@@ -12,6 +12,7 @@ from homeassistant.components.number import NumberEntityDescription
 from homeassistant.components.select import SelectEntityDescription
 from homeassistant.components.sensor import SensorEntityDescription
 from homeassistant.components.switch import SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -19,12 +20,14 @@ from homeassistant.helpers.device_registry import DeviceInfo
 class OpenEVSEEntity:
     """Base class for OpenEVSE entities."""
 
+    _config: ConfigEntry
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return a port description for device registry."""
         return DeviceInfo(
             manufacturer="OpenEVSE",
-            name=self._config.data[CONF_NAME],
+            name=self._config.data.get(CONF_NAME),
             connections={("openevse", self._config.entry_id)},
         )
 

--- a/custom_components/openevse/light.py
+++ b/custom_components/openevse/light.py
@@ -29,7 +29,7 @@ from .const import (
     LIGHT_TYPES,
     MANAGER,
 )
-from .entity import OpenEVSELightEntityDescription
+from .entity import OpenEVSEEntity, OpenEVSELightEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 DEFAULT_ON = 125
@@ -41,21 +41,21 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up OpenEVSE Number entity from Config Entry."""
+    """Set up the OpenEVSE light entities."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     manager = hass.data[DOMAIN][config_entry.entry_id][MANAGER]
 
     entities: list[LightEntity] = []
 
-    for light in LIGHT_TYPES:
-        if LIGHT_TYPES[light].key in coordinator.data:
+    for description in LIGHT_TYPES:
+        if description.key in coordinator.data:
             entities.append(
-                OpenEVSELight(config_entry, coordinator, LIGHT_TYPES[light], manager)
+                OpenEVSELight(config_entry, coordinator, description, manager)
             )
     async_add_entities(entities)
 
 
-class OpenEVSELight(CoordinatorEntity, LightEntity):
+class OpenEVSELight(CoordinatorEntity, OpenEVSEEntity, LightEntity):
     """Implementation of an OpenEVSE light."""
 
     _attr_supported_color_modes: ClassVar[set[ColorMode]] = {ColorMode.BRIGHTNESS}
@@ -84,21 +84,12 @@ class OpenEVSELight(CoordinatorEntity, LightEntity):
         self._attr_name = f"{self._config.data[CONF_NAME]} {self._name}"
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
         data = coordinator.data
-        if isinstance(data, dict) and self._type in data:
+        if getattr(light_description, "value_fn", None) is not None:
+            self._attr_brightness = light_description.value_fn(data)
+        elif isinstance(data, dict) and self._type in data:
             self._attr_brightness = data[self._type]
         else:
             self._attr_brightness = None
-
-    @property
-    def device_info(self) -> dict:
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._unique_id)},
-        }
-
-        return info
 
     @property
     def available(self) -> bool:
@@ -111,7 +102,9 @@ class OpenEVSELight(CoordinatorEntity, LightEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         data = self.coordinator.data
-        if isinstance(data, dict) and self._type in data:
+        if getattr(self.entity_description, "value_fn", None) is not None:
+            self._attr_brightness = self.entity_description.value_fn(data)
+        elif isinstance(data, dict) and self._type in data:
             self._attr_brightness = data[self._type]
         else:
             self._attr_brightness = None

--- a/custom_components/openevse/light.py
+++ b/custom_components/openevse/light.py
@@ -83,10 +83,10 @@ class OpenEVSELight(CoordinatorEntity, OpenEVSEEntity, LightEntity):
 
         self._attr_name = f"{self._config.data[CONF_NAME]} {self._name}"
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
-        data = coordinator.data
+        data = coordinator.data if isinstance(coordinator.data, dict) else {}
         if getattr(light_description, "value_fn", None) is not None:
             self._attr_brightness = light_description.value_fn(data)
-        elif isinstance(data, dict) and self._type in data:
+        elif self._type in data:
             self._attr_brightness = data[self._type]
         else:
             self._attr_brightness = None
@@ -101,10 +101,10 @@ class OpenEVSELight(CoordinatorEntity, OpenEVSEEntity, LightEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        data = self.coordinator.data
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self.entity_description, "value_fn", None) is not None:
             self._attr_brightness = self.entity_description.value_fn(data)
-        elif isinstance(data, dict) and self._type in data:
+        elif self._type in data:
             self._attr_brightness = data[self._type]
         else:
             self._attr_brightness = None

--- a/custom_components/openevse/number.py
+++ b/custom_components/openevse/number.py
@@ -116,12 +116,12 @@ class OpenEVSENumberEntity(CoordinatorEntity, OpenEVSEEntity, NumberEntity):
     @property
     def native_value(self) -> float | None:
         """Return the entity value."""
-        data = self.coordinator.data
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self._description, "value_fn", None) is not None:
             value = self._description.value_fn(data)
             return None if value is None else float(value)
         value = None
-        if isinstance(data, dict) and self._type in data:
+        if self._type in data:
             value = data[self._type]
         self.coordinator.logger.debug(
             "Number [%s] updated value: %s", self._type, value

--- a/custom_components/openevse/number.py
+++ b/custom_components/openevse/number.py
@@ -24,7 +24,7 @@ from .const import (
     MANAGER,
     NUMBER_TYPES,
 )
-from .entity import OpenEVSENumberEntityDescription
+from .entity import OpenEVSEEntity, OpenEVSENumberEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,22 +34,20 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up OpenEVSE Number entity from Config Entry."""
+    """Set up the OpenEVSE number entities."""
     coordinator = hass.data[DOMAIN][config_entry.entry_id][COORDINATOR]
     manager = hass.data[DOMAIN][config_entry.entry_id][MANAGER]
 
     entities: list[NumberEntity] = []
 
-    for number in NUMBER_TYPES:
+    for description in NUMBER_TYPES:
         entities.append(
-            OpenEVSENumberEntity(
-                config_entry, coordinator, NUMBER_TYPES[number], manager
-            )
+            OpenEVSENumberEntity(config_entry, coordinator, description, manager)
         )
     async_add_entities(entities)
 
 
-class OpenEVSENumberEntity(CoordinatorEntity, NumberEntity):
+class OpenEVSENumberEntity(CoordinatorEntity, OpenEVSEEntity, NumberEntity):
     """Representation of a OpenEVSE number entity."""
 
     def __init__(
@@ -62,6 +60,7 @@ class OpenEVSENumberEntity(CoordinatorEntity, NumberEntity):
         """Initialize an OpenEVSE number entity."""
         super().__init__(coordinator)
         self._description = description
+        self.entity_description = description
         self._unique_id = config_entry.entry_id
         self._config = config_entry
         self._name = description.name
@@ -76,16 +75,6 @@ class OpenEVSENumberEntity(CoordinatorEntity, NumberEntity):
         self._attr_name = f"{config_entry.data[CONF_NAME]} {self._name}"
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
         self._attr_native_step = 1.0
-
-    @property
-    def device_info(self):
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._config.entry_id)},
-        }
-        return info
 
     @property
     def available(self) -> bool:
@@ -128,6 +117,9 @@ class OpenEVSENumberEntity(CoordinatorEntity, NumberEntity):
     def native_value(self) -> float | None:
         """Return the entity value."""
         data = self.coordinator.data
+        if getattr(self._description, "value_fn", None) is not None:
+            value = self._description.value_fn(data)
+            return None if value is None else float(value)
         value = None
         if isinstance(data, dict) and self._type in data:
             value = data[self._type]

--- a/custom_components/openevse/select.py
+++ b/custom_components/openevse/select.py
@@ -77,11 +77,11 @@ class OpenEVSESelect(CoordinatorEntity, OpenEVSEEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
-        data = self.coordinator.data
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self.entity_description, "value_fn", None) is not None:
             state = self.entity_description.value_fn(data)
             return None if state is None else str(state)
-        if isinstance(data, dict) and self._type in data:
+        if self._type in data:
             state = data[self._type]
             self.coordinator.logger.debug(
                 "Select [%s] updated value: %s", self._type, state

--- a/custom_components/openevse/select.py
+++ b/custom_components/openevse/select.py
@@ -20,7 +20,7 @@ from . import (
     send_command,
 )
 from .const import CONNECTION_ERROR, COORDINATOR, DOMAIN, MANAGER, SELECT_TYPES
-from .entity import OpenEVSESelectEntityDescription
+from .entity import OpenEVSEEntity, OpenEVSESelectEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,15 +30,19 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
     manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
     selects = []
-    for select in SELECT_TYPES:
-        selects.append(
-            OpenEVSESelect(hass, entry, coordinator, SELECT_TYPES[select], manager)
-        )
+    for description in SELECT_TYPES:
+        if description.key == "max_current_soft":
+            _LOGGER.warning(
+                "The Charge Rate select entity (max_current_soft) is deprecated "
+                "and will be removed in a future release. "
+                "Please use the number entity instead."
+            )
+        selects.append(OpenEVSESelect(hass, entry, coordinator, description, manager))
 
     async_add_entities(selects, False)
 
 
-class OpenEVSESelect(CoordinatorEntity, SelectEntity):
+class OpenEVSESelect(CoordinatorEntity, OpenEVSEEntity, SelectEntity):
     """Define OpenEVSE Service Level select."""
 
     def __init__(
@@ -54,6 +58,7 @@ class OpenEVSESelect(CoordinatorEntity, SelectEntity):
         self.hass = hass
         self._config = config_entry
         self.coordinator = coordinator
+        self.entity_description = description
         self._description = description
         self._type = description.key
         self._attr_name = f"{config_entry.data[CONF_NAME]} {description.name}"
@@ -70,19 +75,12 @@ class OpenEVSESelect(CoordinatorEntity, SelectEntity):
         return self.get_options()
 
     @property
-    def device_info(self):
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._config.entry_id)},
-        }
-        return info
-
-    @property
     def current_option(self) -> str | None:
         """Return the selected entity option to represent the entity state."""
         data = self.coordinator.data
+        if getattr(self.entity_description, "value_fn", None) is not None:
+            state = self.entity_description.value_fn(data)
+            return None if state is None else str(state)
         if isinstance(data, dict) and self._type in data:
             state = data[self._type]
             self.coordinator.logger.debug(

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -69,9 +69,10 @@ class OpenEVSESensor(CoordinatorEntity, OpenEVSEEntity, SensorEntity):
     @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self.entity_description, "value_fn", None) is not None:
-            return self.entity_description.value_fn(self.coordinator.data)
-        return self.coordinator.data.get(self._type)
+            return self.entity_description.value_fn(data)
+        return data.get(self._type)
 
     @property
     def native_unit_of_measurement(self) -> str | None:

--- a/custom_components/openevse/sensor.py
+++ b/custom_components/openevse/sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import UnitOfLength
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_NAME, COORDINATOR, DOMAIN, MANAGER, SENSOR_TYPES
+from .entity import OpenEVSEEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -33,15 +34,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     unique_id = entry.entry_id
 
     sensors = []
-    for sensor in SENSOR_TYPES:
-        sensors.append(
-            OpenEVSESensor(SENSOR_TYPES[sensor], unique_id, coordinator, entry)
-        )
+    for description in SENSOR_TYPES:
+        sensors.append(OpenEVSESensor(description, unique_id, coordinator, entry))
 
     async_add_entities(sensors, False)
 
 
-class OpenEVSESensor(CoordinatorEntity, SensorEntity):
+class OpenEVSESensor(CoordinatorEntity, OpenEVSEEntity, SensorEntity):
     """Implementation of an OpenEVSE sensor."""
 
     def __init__(
@@ -68,19 +67,10 @@ class OpenEVSESensor(CoordinatorEntity, SensorEntity):
         self._attr_unique_id = f"{self._name}_{self._unique_id}"
 
     @property
-    def device_info(self) -> dict:
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._unique_id)},
-        }
-
-        return info
-
-    @property
     def native_value(self) -> Any:
         """Return the state of the sensor."""
+        if getattr(self.entity_description, "value_fn", None) is not None:
+            return self.entity_description.value_fn(self.coordinator.data)
         return self.coordinator.data.get(self._type)
 
     @property

--- a/custom_components/openevse/switch.py
+++ b/custom_components/openevse/switch.py
@@ -75,11 +75,16 @@ class OpenEVSESwitch(CoordinatorEntity, OpenEVSEEntity, SwitchEntity):
         return self._attr_name
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return True if switch is on."""
-        data = self.coordinator.data
+        data = self.coordinator.data if isinstance(self.coordinator.data, dict) else {}
         if getattr(self.entity_description, "value_fn", None) is not None:
             val = self.entity_description.value_fn(data)
+            if val is None:
+                self.coordinator.logger.warning(
+                    "switch [%s] not supported.", self._type
+                )
+                return None
             if self._type == ATTR_STATE:
                 return val == SLEEP_STATE
             return cast(bool, val == 1)

--- a/custom_components/openevse/switch.py
+++ b/custom_components/openevse/switch.py
@@ -19,7 +19,7 @@ from .const import (
     MANAGER,
     SWITCH_TYPES,
 )
-from .entity import OpenEVSESwitchEntityDescription
+from .entity import OpenEVSEEntity, OpenEVSESwitchEntityDescription
 
 _LOGGER = logging.getLogger(__name__)
 SLEEP_STATE = "sleeping"
@@ -32,15 +32,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
     manager = hass.data[DOMAIN][entry.entry_id][MANAGER]
 
     switches = []
-    for switch in SWITCH_TYPES:
-        switches.append(
-            OpenEVSESwitch(hass, entry, coordinator, SWITCH_TYPES[switch], manager)
-        )
+    for description in SWITCH_TYPES:
+        switches.append(OpenEVSESwitch(hass, entry, coordinator, description, manager))
 
     async_add_entities(switches, False)
 
 
-class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
+class OpenEVSESwitch(CoordinatorEntity, OpenEVSEEntity, SwitchEntity):
     """Representation of the value of a OpenEVSE Switch."""
 
     def __init__(
@@ -56,6 +54,7 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
         self.hass = hass
         self._config = config_entry
         self.coordinator = coordinator
+        self.entity_description = description
         self._type = description.key
         self._unique_id = config_entry.entry_id
         self._attr_name = f"{config_entry.data[CONF_NAME]} {description.name}"
@@ -76,20 +75,14 @@ class OpenEVSESwitch(CoordinatorEntity, SwitchEntity):
         return self._attr_name
 
     @property
-    def device_info(self) -> dict:
-        """Return a port description for device registry."""
-        info = {
-            "manufacturer": "OpenEVSE",
-            "name": self._config.data[CONF_NAME],
-            "connections": {(DOMAIN, self._unique_id)},
-        }
-
-        return info
-
-    @property
     def is_on(self) -> bool:
         """Return True if switch is on."""
         data = self.coordinator.data
+        if getattr(self.entity_description, "value_fn", None) is not None:
+            val = self.entity_description.value_fn(data)
+            if self._type == ATTR_STATE:
+                return val == SLEEP_STATE
+            return cast(bool, val == 1)
         if self._type not in data:
             self.coordinator.logger.warning("switch [%s] not supported.", self._type)
             return None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,8 +65,8 @@ async def test_setup_entry(hass, test_charger, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
@@ -86,8 +86,8 @@ async def test_setup_entry_bad_serial(hass, test_charger_bad_serial, mock_ws_sta
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
@@ -138,8 +138,8 @@ async def test_setup_entry_state_change(hass, test_charger, mock_ws_start, caplo
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     await hass.async_block_till_done()
@@ -170,8 +170,8 @@ async def test_setup_entry_state_change_timeout(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     await hass.async_block_till_done()
@@ -202,8 +202,8 @@ async def test_setup_entry_state_change_2(hass, test_charger, mock_ws_start, cap
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     await hass.async_block_till_done()
@@ -239,8 +239,8 @@ async def test_setup_entry_state_change_2_bad_post(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     await hass.async_block_till_done()
@@ -305,8 +305,8 @@ async def test_setup_entry_v2(hass, test_charger_v2, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
-    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -125,7 +125,12 @@ async def test_light_coverage_gaps(hass, test_charger, mock_ws_start):
 
     # Case: coordinator.data is empty during init
     coordinator.data = {}
-    light = OpenEVSELight(entry, coordinator, LIGHT_TYPES["led_brightness"], manager)
+    light = OpenEVSELight(
+        entry,
+        coordinator,
+        next(desc for desc in LIGHT_TYPES if desc.key == "led_brightness"),
+        manager,
+    )
     assert light._attr_brightness is None
 
     # Verify _handle_coordinator_update with missing data

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -9,6 +9,7 @@ from homeassistant.exceptions import HomeAssistantError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openevse.const import COORDINATOR, DOMAIN, LIGHT_TYPES, MANAGER
+from custom_components.openevse.entity import OpenEVSELightEntityDescription
 from custom_components.openevse.light import OpenEVSELight
 
 from .conftest import TEST_URL_CONFIG
@@ -139,6 +140,22 @@ async def test_light_coverage_gaps(hass, test_charger, mock_ws_start):
     with patch.object(light, "async_write_ha_state"):
         light._handle_coordinator_update()
     assert light._attr_brightness is None
+
+    # Case: description has NO value_fn, but key is present during init
+    desc_no_val_fn = OpenEVSELightEntityDescription(
+        key="led_brightness",
+        name="LED Brightness No Value FN",
+        value_fn=None,
+    )
+    coordinator.data = {"led_brightness": 120}
+    light_no_val_fn = OpenEVSELight(entry, coordinator, desc_no_val_fn, manager)
+    assert light_no_val_fn._attr_brightness == 120
+
+    # Case: description has NO value_fn, and we update coordinator.data
+    coordinator.data = {"led_brightness": 80}
+    with patch.object(light_no_val_fn, "async_write_ha_state"):
+        light_no_val_fn._handle_coordinator_update()
+    assert light_no_val_fn._attr_brightness == 80
 
 
 async def test_light_connection_error(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -105,7 +105,10 @@ async def test_number_validation_error(hass, test_charger, mock_ws_start):
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
 
     entity = OpenEVSENumberEntity(
-        entry, coordinator, NUMBER_TYPES["max_current_soft"], manager
+        entry,
+        coordinator,
+        next(desc for desc in NUMBER_TYPES if desc.key == "max_current_soft"),
+        manager,
     )
 
     with pytest.raises(ValueError, match="charge rate must be whole amps"):
@@ -130,7 +133,10 @@ async def test_number_coverage_gaps(hass, test_charger, mock_ws_start):
 
     # 1. Test fallback when coordinator.data is None
     entity = OpenEVSENumberEntity(
-        entry, coordinator, NUMBER_TYPES["max_current_soft"], None
+        entry,
+        coordinator,
+        next(desc for desc in NUMBER_TYPES if desc.key == "max_current_soft"),
+        None,
     )
     coordinator.data = None
     assert entity.native_min_value == 6.0

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,7 +1,7 @@
 """Test OpenEVSE number platform."""
 
 import logging
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
@@ -150,6 +150,24 @@ async def test_number_coverage_gaps(hass, test_charger, mock_ws_start):
     # Verify available when data is not a dict
     coordinator.data = "not a dict"
     assert entity.available == coordinator.last_update_success
+
+    # 3. Test fallback when value_fn is None
+    description_no_val_fn = MagicMock(
+        key="test_key",
+        name="Test",
+        command="test",
+        min_version=None,
+        value_fn=None,
+        native_unit_of_measurement=None,
+    )
+    entity_no_val_fn = OpenEVSENumberEntity(
+        entry,
+        coordinator,
+        description_no_val_fn,
+        None,
+    )
+    coordinator.data = {"test_key": 25.0}
+    assert entity_no_val_fn.native_value == 25.0
 
 
 async def test_number_connection_error(

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -45,6 +45,19 @@ async def test_select(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
+    # Enable disabled select
+    charge_rate_entity_id = "select.openevse_charge_rate"
+    entity_entry = entity_registry.async_get(charge_rate_entity_id)
+    updated_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, disabled_by=None
+    )
+    assert updated_entry.disabled is False
+
+    # Reload to apply enabled state
+    await hass.config_entries.async_forward_entry_unload(entry, SELECT_DOMAIN)
+    await hass.config_entries.async_forward_entry_setups(entry, [SELECT_DOMAIN])
+    await hass.async_block_till_done()
+
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 3
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -172,6 +185,14 @@ async def test_select_max_current(
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+
+    # Enable disabled select
+    entity_entry = entity_registry.async_get("select.openevse_charge_rate")
+    entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
+    await hass.config_entries.async_forward_entry_unload(entry, SELECT_DOMAIN)
+    await hass.config_entries.async_forward_entry_setups(entry, [SELECT_DOMAIN])
+    await hass.async_block_till_done()
+
     entity_id = "select.openevse_charge_rate"
     state = hass.states.get(entity_id)
 
@@ -193,7 +214,12 @@ async def test_select_max_current(
 
 
 async def test_select_availability_divert(
-    hass, test_charger, mock_ws_start, mock_aioclient, caplog
+    hass,
+    test_charger,
+    mock_ws_start,
+    mock_aioclient,
+    entity_registry: er.EntityRegistry,
+    caplog,
 ):
     """Test that charge rate select becomes unavailable when divert is active."""
     entry = MockConfigEntry(
@@ -203,6 +229,13 @@ async def test_select_availability_divert(
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Enable disabled select
+    entity_entry = entity_registry.async_get("select.openevse_charge_rate")
+    entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
+    await hass.config_entries.async_forward_entry_unload(entry, SELECT_DOMAIN)
+    await hass.config_entries.async_forward_entry_setups(entry, [SELECT_DOMAIN])
     await hass.async_block_till_done()
 
     entity_id = "select.openevse_charge_rate"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,7 +3,7 @@
 import contextlib
 import logging
 from datetime import datetime
-from unittest.mock import PropertyMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from aiohttp import ClientError
@@ -14,6 +14,7 @@ from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.openevse.const import DOMAIN
+from custom_components.openevse.sensor import OpenEVSESensor
 
 from .const import CONFIG_DATA
 
@@ -459,3 +460,25 @@ async def test_vehicle_range_sensor_km(
         entity = hass.data["entity_components"]["sensor"].get_entity(entity_id)
         assert entity
         assert entity.native_unit_of_measurement == UnitOfLength.KILOMETERS
+
+
+async def test_sensor_coverage_gaps(hass, test_charger, mock_ws_start):
+    """Test sensor coverage gaps."""
+    entry = MockConfigEntry(domain=DOMAIN, data=CONFIG_DATA)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    description_no_val_fn = MagicMock(
+        key="test_sensor_key",
+        name="Test Sensor",
+        min_version=None,
+        value_fn=None,
+        native_unit_of_measurement=None,
+        icon=None,
+    )
+    entity = OpenEVSESensor(description_no_val_fn, "test_unique_id", coordinator, entry)
+    coordinator.data = {"test_sensor_key": "some_value"}
+    assert entity.native_value == "some_value"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -299,6 +299,19 @@ async def test_switch_coverage_gaps(hass, test_charger, mock_ws_start):
     switch = OpenEVSESwitch(hass, entry, coordinator, description, manager)
     assert switch.is_on is None
 
+    # Test is_on when value_fn returns None
+    description_value_fn = MagicMock(
+        key="test_value_fn",
+        name="ValueFnTest",
+        toggle_command="test",
+        min_version=None,
+        value_fn=lambda d: None,
+    )
+    switch_value_fn = OpenEVSESwitch(
+        hass, entry, coordinator, description_value_fn, manager
+    )
+    assert switch_value_fn.is_on is None
+
     # Test toggling of claim-based switches
     description_claim = MagicMock(
         key="state",

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -28,6 +28,7 @@ async def test_switches(
     test_charger,
     mock_ws_start,
     mock_aioclient,
+    entity_registry: er.EntityRegistry,
 ):
     """Test standard switches."""
     entry = MockConfigEntry(
@@ -37,6 +38,16 @@ async def test_switches(
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Enable disabled switches
+    for entity_id in ("switch.openevse_sleep_mode", "switch.openevse_sleep_mode_new"):
+        entity_entry = entity_registry.async_get(entity_id)
+        entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
+
+    # Reload to apply enabled state
+    await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)
+    await hass.config_entries.async_forward_entry_setups(entry, [SWITCH_DOMAIN])
     await hass.async_block_till_done()
 
     # Ensure all switches are created
@@ -240,6 +251,21 @@ async def test_switches_v2(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
+        # Enable disabled switches
+        for entity_id in (
+            "switch.openevse_sleep_mode",
+            "switch.openevse_sleep_mode_new",
+        ):
+            entity_entry = entity_registry.async_get(entity_id)
+            entity_registry.async_update_entity(
+                entity_entry.entity_id, disabled_by=None
+            )
+
+        # Reload to apply enabled state
+        await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)
+        await hass.config_entries.async_forward_entry_setups(entry, [SWITCH_DOMAIN])
+        await hass.async_block_till_done()
+
         assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
@@ -264,14 +290,22 @@ async def test_switch_coverage_gaps(hass, test_charger, mock_ws_start):
 
     # Test is_on when data is missing
     description = MagicMock(
-        key="missing_switch", name="Missing", toggle_command="test", min_version=None
+        key="missing_switch",
+        name="Missing",
+        toggle_command="test",
+        min_version=None,
+        value_fn=None,
     )
     switch = OpenEVSESwitch(hass, entry, coordinator, description, manager)
     assert switch.is_on is None
 
     # Test toggling of claim-based switches
     description_claim = MagicMock(
-        key="state", name="Claim", toggle_command="claim", min_version=None
+        key="state",
+        name="Claim",
+        toggle_command="claim",
+        min_version=None,
+        value_fn=None,
     )
     switch_claim = OpenEVSESwitch(hass, entry, coordinator, description_claim, manager)
 
@@ -304,6 +338,7 @@ async def test_switch_connection_error(
     test_charger,
     mock_ws_start,
     mock_aioclient,
+    entity_registry: er.EntityRegistry,
     caplog,
 ):
     """Test switch platform with connection error."""
@@ -315,6 +350,15 @@ async def test_switch_connection_error(
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Enable disabled switch
+    entity_entry = entity_registry.async_get("switch.openevse_sleep_mode")
+    entity_registry.async_update_entity(entity_entry.entity_id, disabled_by=None)
+
+    # Reload to apply enabled state
+    await hass.config_entries.async_forward_entry_unload(entry, SWITCH_DOMAIN)
+    await hass.config_entries.async_forward_entry_setups(entry, [SWITCH_DOMAIN])
     await hass.async_block_till_done()
 
     manager = hass.data[DOMAIN][entry.entry_id][MANAGER]


### PR DESCRIPTION
## Description

This PR refactors all entity description collections across the OpenEVSE integration from dictionaries to tuples of description classes, mirroring the style and patterns used in the `home-assistant/core` integration. 

Specifically, this PR:
1. Implements a `value_fn` parameter on all stateful entity description classes to retrieve values directly from the coordinator's data dictionary (e.g. `value_fn=lambda data: data.get("key")`).
2. Correctly assigns `self.entity_description = description` to entity platforms so registry defaults (like `entity_registry_enabled_default=False`) are properly respected.
3. Unifies duplicate `device_info` code by introducing a shared `OpenEVSEEntity` base mixin class in `entity.py` that all entity platforms inherit from.
4. Adds a deprecation warning for the `max_current_soft` select entity.
5. Fixes the unit tests to correctly enable default-disabled entities in the entity registry and adjusts test assertions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality / Refactoring
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured entity configuration architecture for improved consistency and maintainability.

* **Tests**
  * Updated test coverage to reflect reduced default entity count: switch entities reduced from 6 to 4, select entities reduced from 3 to 2.
  * Added tests for disabled entity state handling and entity-registry updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->