### PR TITLE
refactor(tests): replace aioresponses with aioclient_mock

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,7 +3,6 @@ pytest-homeassistant-custom-component
 mypy==2.1.0
 ruff==0.15.20
 tox==4.56.1
-aioresponses
 pytest<10
 aiohttp_cors
 zeroconf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 import openevsehttp.__main__ as main
 import pytest
-from aioresponses import aioresponses
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
     TYPE_AUTH_OK,
@@ -104,99 +103,83 @@ def test_charger(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.get(
         TEST_URL_STATUS.replace("http://", "https://"),
         status=200,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.post(
         TEST_URL_STATUS,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.post(
         TEST_URL_STATUS.replace("http://", "https://"),
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("config.json"),
-        repeat=True,
+        text=load_fixture("config.json"),
     )
     mock_aioclient.get(
         TEST_URL_CONFIG.replace("http://", "https://"),
         status=200,
-        body=load_fixture("config.json"),
-        repeat=True,
+        text=load_fixture("config.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS.replace("ws://", "wss://"),
         status=101,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.post(
         TEST_URL_OVERRIDE.replace("http://", "https://"),
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.patch(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.patch(
         TEST_URL_OVERRIDE.replace("http://", "https://"),
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE.replace("http://", "https://"),
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET.replace("http://", "https://"),
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     return main.OpenEVSE(TEST_TLD)
 
@@ -207,39 +190,33 @@ def test_charger_services(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.post(
         TEST_URL_STATUS,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("config.json"),
-        repeat=True,
+        text=load_fixture("config.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     return main.OpenEVSE(TEST_TLD)
 
@@ -250,33 +227,28 @@ def test_charger_bad_serial(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("config-no-serial.json"),
-        repeat=True,
+        text=load_fixture("config-no-serial.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     return main.OpenEVSE(TEST_TLD)
 
@@ -287,38 +259,32 @@ def test_charger_bad_post(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     mock_aioclient.post(
         TEST_URL_STATUS,
-        exception=TimeoutError,
-        repeat=True,
+        exc=TimeoutError,
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("config.json"),
-        repeat=True,
+        text=load_fixture("config.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("status.json"),
-        repeat=True,
+        text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     return main.OpenEVSE(TEST_TLD)
 
@@ -329,45 +295,38 @@ def test_charger_new(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("status-new.json"),
-        repeat=True,
+        text=load_fixture("status-new.json"),
     )
     mock_aioclient.post(
         TEST_URL_STATUS,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("config.json"),
-        repeat=True,
+        text=load_fixture("config.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("status-new.json"),
-        repeat=True,
+        text=load_fixture("status-new.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=200,
-        body='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
-        repeat=True,
+        text='{"properties":{"state":"disabled","charge_current":28,"max_current":23,"auto_release":false},"claims":{"state":65540,"charge_current":65537,"max_current":65548}}',
     )
     return main.OpenEVSE(TEST_TLD)
 
@@ -381,10 +340,9 @@ def mock_manager():
 
 
 @pytest.fixture
-def mock_aioclient():
+def mock_aioclient(aioclient_mock):
     """Fixture to mock aioclient calls."""
-    with aioresponses(passthrough=["http://127.0.0.1"]) as m:
-        yield m
+    return aioclient_mock
 
 
 def load_fixture(filename):
@@ -401,14 +359,12 @@ def register_github_release_mocks(
     mock_aioclient.get(
         TEST_URL_GITHUB_V4,
         status=200,
-        body=load_fixture(v4_repo),
-        repeat=True,
+        text=load_fixture(v4_repo),
     )
     mock_aioclient.get(
         TEST_URL_GITHUB_V2,
         status=200,
-        body=load_fixture(v2_repo),
-        repeat=True,
+        text=load_fixture(v2_repo),
     )
 
 
@@ -418,45 +374,38 @@ def test_charger_v2(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_STATUS,
         status=200,
-        body=load_fixture("v2_status.json"),
-        repeat=True,
+        text=load_fixture("v2_status.json"),
     )
     mock_aioclient.post(
         TEST_URL_STATUS,
         status=200,
-        body='{ "msg": "OK" }',
-        repeat=True,
+        text='{ "msg": "OK" }',
     )
     mock_aioclient.get(
         TEST_URL_CONFIG,
         status=200,
-        body=load_fixture("v2_config.json"),
-        repeat=True,
+        text=load_fixture("v2_config.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
-        body=load_fixture("v2_status.json"),
-        repeat=True,
+        text=load_fixture("v2_status.json"),
     )
     register_github_release_mocks(mock_aioclient)
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=404,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=404,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     mock_aioclient.get(
         TEST_URL_CLAIMS_TARGET,
         status=404,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     return main.OpenEVSE(TEST_TLD)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,8 @@ async def patched_match_request(self, method, url, **kwargs):
         key = headers["Sec-WebSocket-Key"]
         accept_val = base64.b64encode(
             hashlib.sha1(
-                (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()
+                (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode(),
+                usedforsecurity=False,
             ).digest()
         ).decode()
         resp._headers["Sec-WebSocket-Accept"] = accept_val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Global fixtures for openevse integration."""
 
+import base64
+import hashlib
 import os
 from collections.abc import Coroutine, Generator
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import openevsehttp.__main__ as main
 import pytest
@@ -17,6 +19,10 @@ from homeassistant.core import (
     HomeAssistant,
 )
 from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.test_util.aiohttp import (
+    AiohttpClientMocker,
+    AiohttpClientMockResponse,
+)
 
 from tests.const import CHARGER_DATA, FW_DATA, GETFW_DATA
 
@@ -27,6 +33,57 @@ from .typing import (
 )
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+# Patch AiohttpClientMockResponse to have request_info and history
+# for Python 3.14 / aiohttp compatibility
+if not hasattr(AiohttpClientMockResponse, "request_info"):
+
+    @property
+    def request_info(self):
+        """Return request info."""
+        return Mock(real_url=self.url)
+
+    AiohttpClientMockResponse.request_info = request_info
+
+if not hasattr(AiohttpClientMockResponse, "history"):
+
+    @property
+    def history(self):
+        """Return history."""
+        return ()
+
+    AiohttpClientMockResponse.history = history
+
+if not hasattr(AiohttpClientMockResponse, "connection"):
+
+    @property
+    def connection(self):
+        """Return connection mock."""
+        conn = Mock()
+        conn._connector._timeout_ceil_threshold = 5
+        return conn
+
+    AiohttpClientMockResponse.connection = connection
+
+# Patch AiohttpClientMocker to calculate challenge response for websocket handshakes
+orig_match_request = AiohttpClientMocker.match_request
+
+
+async def patched_match_request(self, method, url, **kwargs):
+    headers = kwargs.get("headers") or {}
+    resp = await orig_match_request(self, method, url, **kwargs)
+    if resp.status == 101 and "Sec-WebSocket-Key" in headers:
+        key = headers["Sec-WebSocket-Key"]
+        accept_val = base64.b64encode(
+            hashlib.sha1(
+                (key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode()
+            ).digest()
+        ).decode()
+        resp._headers["Sec-WebSocket-Accept"] = accept_val
+    return resp
+
+
+AiohttpClientMocker.match_request = patched_match_request
 
 TEST_URL_GITHUB_V4 = (
     "https://api.github.com/repos/OpenEVSE/ESP32_WiFi_V4.x/releases/latest"
@@ -133,11 +190,13 @@ def test_charger(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status.json"),
     )
     mock_aioclient.get(
         TEST_URL_WS.replace("ws://", "wss://"),
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
@@ -205,6 +264,7 @@ def test_charger_services(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
@@ -237,6 +297,7 @@ def test_charger_bad_serial(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
@@ -273,6 +334,7 @@ def test_charger_bad_post(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status.json"),
     )
     register_github_release_mocks(mock_aioclient)
@@ -310,6 +372,7 @@ def test_charger_new(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("status-new.json"),
     )
     register_github_release_mocks(mock_aioclient)
@@ -389,6 +452,7 @@ def test_charger_v2(mock_aioclient):
     mock_aioclient.get(
         TEST_URL_WS,
         status=101,
+        headers={"Upgrade": "websocket", "Connection": "Upgrade"},
         text=load_fixture("v2_status.json"),
     )
     register_github_release_mocks(mock_aioclient)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -489,6 +489,10 @@ async def test_options_flow(hass, test_charger, mock_ws_start):
         "invert_grid": False,
     }
 
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
 
 async def test_options_flow_defaults(hass, test_charger, mock_ws_start):
     """Test options flow shows existing values as defaults."""
@@ -526,6 +530,10 @@ async def test_options_flow_defaults(hass, test_charger, mock_ws_start):
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"]["solar"] == "sensor.solar_production"
+
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_options_flow_all_empty_entities(hass, test_charger, mock_ws_start):
@@ -576,6 +584,10 @@ async def test_options_flow_all_empty_entities(hass, test_charger, mock_ws_start
         "invert_grid": False,
     }
 
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
 
 async def test_migrate_from_v1(hass, test_charger, mock_ws_start):
     """Test migration from config version 1 to version 2."""
@@ -617,6 +629,10 @@ async def test_migrate_from_v1(hass, test_charger, mock_ws_start):
     # Verify connection data is preserved
     assert entry.data.get("host") == "openevse.test.tld"
     assert entry.data.get("name") == "openevse"
+
+    await hass.async_block_till_done()
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_form_user_invalid_auth(hass):

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -20,6 +20,14 @@ pytestmark = pytest.mark.asyncio
 CHARGER_NAME = "openevse"
 
 
+def _assert_config_post(mock_aioclient, payload):
+    """Assert a POST request to /config with given payload was made."""
+    assert any(
+        call[0] == "POST" and call[1].path == "/config" and call[2] == payload
+        for call in mock_aioclient.mock_calls
+    )
+
+
 async def test_light(
     hass,
     test_charger,
@@ -62,12 +70,7 @@ async def test_light(
         blocking=True,
     )
 
-    assert any(
-        call[0] == "POST"
-        and call[1].path == "/config"
-        and call[2] == {"led_brightness": 0}
-        for call in mock_aioclient.mock_calls
-    )
+    _assert_config_post(mock_aioclient, {"led_brightness": 0})
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -76,12 +79,7 @@ async def test_light(
         blocking=True,
     )
 
-    assert any(
-        call[0] == "POST"
-        and call[1].path == "/config"
-        and call[2] == {"led_brightness": 125}
-        for call in mock_aioclient.mock_calls
-    )
+    _assert_config_post(mock_aioclient, {"led_brightness": 125})
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
@@ -90,12 +88,7 @@ async def test_light(
         blocking=True,
     )
 
-    assert any(
-        call[0] == "POST"
-        and call[1].path == "/config"
-        and call[2] == {"led_brightness": 26}
-        for call in mock_aioclient.mock_calls
-    )
+    _assert_config_post(mock_aioclient, {"led_brightness": 26})
 
 
 async def test_light_v2(

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -52,8 +52,7 @@ async def test_light(
     mock_aioclient.post(
         TEST_URL_CONFIG,
         status=200,
-        body='{"msg": "OK"}',
-        repeat=True,
+        text='{"msg": "OK"}',
     )
 
     await hass.services.async_call(
@@ -63,8 +62,11 @@ async def test_light(
         blocking=True,
     )
 
-    mock_aioclient.assert_any_call(
-        TEST_URL_CONFIG, method="POST", data={ATTR_BRIGHTNESS: 0}
+    assert any(
+        call[0] == "POST"
+        and call[1].path == "/config"
+        and call[2] == {"led_brightness": 0}
+        for call in mock_aioclient.mock_calls
     )
 
     await hass.services.async_call(
@@ -74,8 +76,11 @@ async def test_light(
         blocking=True,
     )
 
-    mock_aioclient.assert_any_call(
-        TEST_URL_CONFIG, method="POST", data={ATTR_BRIGHTNESS: 128}
+    assert any(
+        call[0] == "POST"
+        and call[1].path == "/config"
+        and call[2] == {"led_brightness": 125}
+        for call in mock_aioclient.mock_calls
     )
 
     await hass.services.async_call(
@@ -85,8 +90,11 @@ async def test_light(
         blocking=True,
     )
 
-    mock_aioclient.assert_any_call(
-        TEST_URL_CONFIG, method="POST", data={ATTR_BRIGHTNESS: 26}
+    assert any(
+        call[0] == "POST"
+        and call[1].path == "/config"
+        and call[2] == {"led_brightness": 26}
+        for call in mock_aioclient.mock_calls
     )
 
 

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -93,7 +93,7 @@ async def test_select(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
 
     servicedata = {
@@ -145,7 +145,7 @@ async def test_select(
     mock_aioclient.post(
         TEST_URL_DIVERT,
         status=200,
-        body=value,
+        text=value,
     )
 
     servicedata = {
@@ -504,7 +504,7 @@ async def test_select_clear_override_not_active(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=500,
-        body='{"msg": "Failed to release manual override"}',
+        text='{"msg": "Failed to release manual override"}',
     )
 
     servicedata = {
@@ -542,7 +542,7 @@ async def test_select_clear_override_other_runtime_error(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=500,
-        body='{"msg": "Some other server error"}',
+        text='{"msg": "Some other server error"}',
     )
 
     servicedata = {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -325,8 +325,8 @@ async def test_sensor_availability_aioclient(
     }
 
     for url in urls:
-        mock_aioclient.get(url, status=200, payload=valid_response, repeat=True)
-        mock_aioclient.post(url, status=200, payload=valid_response, repeat=True)
+        mock_aioclient.get(url, status=200, json=valid_response)
+        mock_aioclient.post(url, status=200, json=valid_response)
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -339,11 +339,11 @@ async def test_sensor_availability_aioclient(
     await hass.async_block_till_done()
 
     coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    mock_aioclient.clear()
+    mock_aioclient.clear_requests()
 
     for url in urls:
-        mock_aioclient.get(url, exception=ClientError("Network Down"), repeat=True)
-        mock_aioclient.post(url, exception=ClientError("Network Down"), repeat=True)
+        mock_aioclient.get(url, exc=ClientError("Network Down"))
+        mock_aioclient.post(url, exc=ClientError("Network Down"))
 
     with contextlib.suppress(ClientError):
         await coordinator.async_refresh()
@@ -353,10 +353,10 @@ async def test_sensor_availability_aioclient(
     state = hass.states.get("sensor.openevse_charging_status")
     assert state.state == "unavailable"
 
-    mock_aioclient.clear()
+    mock_aioclient.clear_requests()
     for url in urls:
-        mock_aioclient.get(url, status=200, payload=valid_response, repeat=True)
-        mock_aioclient.post(url, status=200, payload=valid_response, repeat=True)
+        mock_aioclient.get(url, status=200, json=valid_response)
+        mock_aioclient.post(url, status=200, json=valid_response)
 
     await coordinator.async_refresh()
     await hass.async_block_till_done()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -61,14 +61,12 @@ async def test_list_claims(
     mock_aioclient.get(
         TEST_URL_CLAIMS,
         status=200,
-        body='[{"client": 4, "priority": 500, "state": "disabled", "auto_release": true}, {"client": 65538, "priority": 50, "state": "active", "charge_current": 7, "auto_release": false}]',  # noqa: E501
-        repeat=True,
+        text='[{"client": 4, "priority": 500, "state": "disabled", "auto_release": true}, {"client": 65538, "priority": 50, "state": "active", "charge_current": 7, "auto_release": false}]',  # noqa: E501
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -121,14 +119,12 @@ async def test_make_claim(
     mock_aioclient.post(
         f"{TEST_URL_CLAIMS}/20",
         status=200,
-        body='[{"msg":"done"}]',
-        repeat=True,
+        text='[{"msg":"done"}]',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -169,14 +165,12 @@ async def test_release_claim(
     mock_aioclient.delete(
         f"{TEST_URL_CLAIMS}/20",
         status=200,
-        body='[{"msg":"done"}]',
-        repeat=True,
+        text='[{"msg":"done"}]',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -214,14 +208,12 @@ async def test_get_limit(
     mock_aioclient.get(
         TEST_URL_LIMIT,
         status=200,
-        body='{"type": "energy", "value": 10}',
-        repeat=True,
+        text='{"type": "energy", "value": 10}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -260,13 +252,12 @@ async def test_clear_limit(
     mock_aioclient.delete(
         TEST_URL_LIMIT,
         status=200,
-        body='{"msg": "Deleted"}',
+        text='{"msg": "Deleted"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -304,20 +295,17 @@ async def test_set_limit(
     mock_aioclient.post(
         TEST_URL_LIMIT,
         status=200,
-        body='{"msg": "OK"}',
-        repeat=True,
+        text='{"msg": "OK"}',
     )
     mock_aioclient.get(
         TEST_URL_LIMIT,
         status=200,
-        body='{"type": "energy", "value": 10}',
-        repeat=True,
+        text='{"type": "energy", "value": 10}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -359,13 +347,12 @@ async def test_clear_override(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -403,13 +390,12 @@ async def test_clear_override_not_active(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=500,
-        body='{"msg": "Failed to release manual override"}',
+        text='{"msg": "Failed to release manual override"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -447,13 +433,12 @@ async def test_clear_override_other_runtime_error(
     mock_aioclient.delete(
         TEST_URL_OVERRIDE,
         status=500,
-        body='{"msg": "Some other server error"}',
+        text='{"msg": "Some other server error"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -498,8 +483,7 @@ async def test_list_overrides(
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body=json.dumps(value),
-        repeat=True,
+        text=json.dumps(value),
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -538,13 +522,12 @@ async def test_set_override(
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -586,14 +569,12 @@ async def test_make_claim_with_arguments(
     mock_aioclient.post(
         f"{TEST_URL_CLAIMS}/20",
         status=200,
-        body='[{"msg":"done"}]',
-        repeat=True,
+        text='[{"msg":"done"}]',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -636,14 +617,13 @@ async def test_set_override_all_args(
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
     # Ensure get override is mocked to avoid errors during setup/teardown updates
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -686,19 +666,17 @@ async def test_set_limit_auto_release(
     mock_aioclient.post(
         TEST_URL_LIMIT,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
     mock_aioclient.get(
         TEST_URL_LIMIT,
         status=200,
-        body='{"type": "time", "value": 60, "auto_release": false}',
-        repeat=True,
+        text='{"type": "time", "value": 60, "auto_release": false}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -733,7 +711,7 @@ async def test_service_invalid_device_id(
         title=CHARGER_NAME,
         data=CONFIG_DATA,
     )
-    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, body="{}", repeat=True)
+    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, text="{}")
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -786,7 +764,7 @@ async def test_service_missing_config(
         title=CHARGER_NAME,
         data=CONFIG_DATA,
     )
-    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, body="{}", repeat=True)
+    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, text="{}")
 
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
@@ -850,22 +828,19 @@ async def test_services_with_none_values(
     mock_aioclient.post(
         f"{TEST_URL_CLAIMS}/20",
         status=200,
-        body='[{"msg":"done"}]',
-        repeat=True,
+        text='[{"msg":"done"}]',
     )
 
     # Mock set_override endpoint
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
-        repeat=True,
+        text='{"msg": "OK"}',
     )
     mock_aioclient.get(
         TEST_URL_OVERRIDE,
         status=200,
-        body="{}",
-        repeat=True,
+        text="{}",
     )
 
     entry.add_to_hass(hass)
@@ -947,7 +922,7 @@ async def test_services_connection_errors(
         title=CHARGER_NAME,
         data=CONFIG_DATA,
     )
-    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, body="{}", repeat=True)
+    mock_aioclient.get(TEST_URL_OVERRIDE, status=200, text="{}")
     entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -69,7 +69,7 @@ async def test_switches(
     mock_aioclient.post(
         TEST_URL_OVERRIDE,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
 
     await hass.services.async_call(
@@ -98,7 +98,7 @@ async def test_switches(
     mock_aioclient.post(
         TEST_URL_CONFIG,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
 
     # Action: Turn On
@@ -126,7 +126,7 @@ async def test_switches(
     mock_aioclient.post(
         TEST_URL_DIVERT,
         status=200,
-        body='{"msg": "OK"}',
+        text='{"msg": "OK"}',
     )
 
     # Action: Turn On
@@ -154,8 +154,7 @@ async def test_switches(
     mock_aioclient.post(
         TEST_URL_SHAPER,
         status=200,
-        body='{"msg": "Current Shaper state changed"}',
-        repeat=True,
+        text='{"msg": "Current Shaper state changed"}',
     )
 
     # Action: Turn Off
@@ -200,8 +199,7 @@ async def test_switches(
     mock_aioclient.post(
         "http://openevse.test.tld/config",
         status=200,
-        body='{"msg": "OK"}',
-        repeat=True,
+        text='{"msg": "OK"}',
     )
 
     await hass.services.async_call(


### PR DESCRIPTION
## Description

Migrated the unit tests from `aioresponses` to the standard `aioclient_mock` fixture from `pytest-homeassistant-custom-component` and removed the `aioresponses` test dependency.

## Type of change

- [x] Code quality / Refactoring

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test and mock behavior for network and websocket interactions, helping prevent compatibility issues and flaky failures.
  * Added better cleanup after configuration and migration flows to keep tests isolated and reliable.

* **Chores**
  * Updated test fixtures to match the current mocking interface and response format.
  * Removed an unneeded test dependency from the project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->