### PR TITLE
fix: rate-limit async updates during websocket updates (fixes #670)

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -6,6 +6,7 @@ import asyncio
 import functools
 import inspect
 import logging
+import time
 from datetime import timedelta
 from typing import Any
 
@@ -565,6 +566,7 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         self._data = {}
         self._update_lock = asyncio.Lock()
         self._manager.callback = self.websocket_update
+        self._last_async_update = 0.0
 
         self.logger = OpenEVSELoggerAdapter(
             _LOGGER, {"device_name": config.data.get(CONF_NAME, "OpenEVSE")}
@@ -579,6 +581,23 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
             name=self.name,
             update_interval=self.interval,
         )
+
+    @property
+    def async_update_cooldown(self) -> float:
+        """Return the cooldown period based on connection type and hardware firmware."""
+        if getattr(self._manager, "using_ethernet", False):
+            return 2.0
+
+        # Check if ESP32 firmware (v5.x or newer) is running
+        fw = getattr(self._manager, "wifi_firmware", "") or ""
+        if fw.startswith("v"):
+            parts = fw[1:].split(".")
+            if parts and parts[0].isdigit():
+                major_version = int(parts[0])
+                if major_version >= 5:
+                    return 5.0  # ESP32 on Wi-Fi
+
+        return 15.0  # ESP8266 or fallback on Wi-Fi
 
     async def _async_update_data(self):
         """Return data."""
@@ -637,7 +656,7 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         self.logger.debug("Websocket update!")
         try:
             async with self._update_lock:
-                await self._update_data_snapshot()
+                await self._update_data_snapshot(skip_async=True)
         except CONNECTION_ERRORS as error:
             self.logger.warning(
                 "Connection error updating data from websocket [%s]: %s",
@@ -665,10 +684,24 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         except KeyError as err:
             self.logger.error("Error locating configuration: %s", err)
 
-    async def _update_data_snapshot(self) -> None:
+    async def _update_data_snapshot(self, skip_async: bool = False) -> None:
         """Update the data snapshot."""
         new_data = self.parse_sensors()
-        new_data.update(await self.async_parse_sensors())
+
+        now = time.monotonic()
+        should_fetch_async = not skip_async or (
+            now - self._last_async_update > self.async_update_cooldown
+        )
+
+        if should_fetch_async:
+            new_data.update(await self.async_parse_sensors())
+            self._last_async_update = now
+        else:
+            # Retain existing async values from the previous snapshot
+            for key, value in self._data.items():
+                if key not in new_data:
+                    new_data[key] = value
+
         self._data = new_data
 
     def _normalize_descriptors(self, descriptors) -> list[tuple[str, Any]]:

--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -694,8 +694,8 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         )
 
         if should_fetch_async:
-            new_data.update(await self.async_parse_sensors())
             self._last_async_update = now
+            new_data.update(await self.async_parse_sensors())
         else:
             # Retain existing async values from the previous snapshot
             for key, value in self._data.items():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1297,3 +1297,46 @@ async def test_setup_entry_state_change_home_battery(
         hass.states.async_set(power_entity, "-501")
         await hass.async_block_till_done()
     assert "Error connecting to device:" in caplog.text
+
+
+async def test_async_update_cooldown(hass, test_charger, mock_ws_start):
+    """Test async_update_cooldown property of OpenEVSEUpdateCoordinator."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=CHARGER_NAME,
+        data=CONFIG_DATA,
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
+    manager = coordinator._manager
+
+    # Save original state to restore later
+    orig_status = manager._status.copy()
+    orig_config = manager._config.copy()
+
+    try:
+        # Case 1: using_ethernet is True
+        manager._status["eth_connected"] = True
+        assert coordinator.async_update_cooldown == 2.0
+
+        # Case 2: using_ethernet is False, wifi_firmware is v4.1.2
+        manager._status["eth_connected"] = False
+        manager._config["version"] = "v4.1.2"
+        assert coordinator.async_update_cooldown == 15.0
+
+        # Case 3: using_ethernet is False, wifi_firmware is v5.1.5
+        manager._status["eth_connected"] = False
+        manager._config["version"] = "v5.1.5"
+        assert coordinator.async_update_cooldown == 5.0
+
+        # Case 4: wifi_firmware is invalid or None
+        manager._status["eth_connected"] = False
+        manager._config["version"] = None
+        assert coordinator.async_update_cooldown == 15.0
+    finally:
+        manager._status = orig_status
+        manager._config = orig_config


### PR DESCRIPTION
Resolves #670 

### Description
Websocket updates can be triggered frequently. When a websocket message is received, the integration calls `_update_data_snapshot` which invokes all async sensors (such as `/override` and `/claims/target` HTTP GET calls). 

Spamming these concurrent HTTP requests overloads the embedded web server on the ESP8266 or ESP32 board, causing connection timeouts on the client.

### Solution
This PR implements a dynamic cooldown rate-limiter for async requests triggered during websocket updates:
* **Ethernet**: `2.0` seconds cooldown
* **ESP32 Wi-Fi (v5.x+)**: `5.0` seconds cooldown
* **ESP8266 / Fallback Wi-Fi**: `15.0` seconds cooldown

If the websocket triggers an update while the cooldown is active, the integration skips the HTTP calls and falls back to using cached values from the previous snapshot. Full periodic polls (every 60 seconds) bypass the cooldown to keep everything synced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced unnecessary background sensor processing during frequent device updates.
  * Adjusted update timing based on connection type and firmware version.
  * Preserved previously reported sensor values when a full refresh is deferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->