### PR TITLE
chore: update release-drafter configuration to new schema (PR #1558)

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -86,40 +86,40 @@ categories:
 autolabeler:
   - label: "breaking-change"
     title:
-      - '/^[a-z]+\([^)]+\)?:/i'
+      - '/^[^\\s!]+!(\\( [^)]+ \\))?:/i'
   - label: "feature"
     title:
-      - '/^feat\([^)]+\):/i'
+      - '/^feat\\([^)]+\\):/i'
   - label: "bugfix"
     title:
-      - '/^fix\([^)]+\):/i'
+      - '/^fix\\([^)]+\\):/i'
   - label: "refactor"
     title:
-      - '/^refactor\([^)]+\):/i'
+      - '/^refactor\\([^)]+\\):/i'
   - label: "code-quality"
     title:
-      - '/^test\([^)]+\):/i'
+      - '/^test\\([^)]+\\):/i'
   - label: "CI"
     title:
-      - '/^ci\([^)]+\):/i'
+      - '/^ci\\([^)]+\\):/i'
   - label: "chore"
     title:
-      - '/^chore\([^)]+\):/i'
+      - '/^chore\\([^)]+\\):/i'
   - label: "documentation"
     title:
-      - '/^docs\([^)]+\):/i'
+      - '/^docs\\([^)]+\\):/i'
   - label: "style"
     title:
-      - '/^style\([^)]+\):/i'
+      - '/^style\\([^)]+\\):/i'
   - label: "performance"
     title:
-      - '/^perf\([^)]+\):/i'
+      - '/^perf\\([^)]+\\):/i'
   - label: "revert"
     title:
-      - '/^revert\([^)]+\):/i'
+      - '/^revert\\([^)]+\\):/i'
   - label: "build"
     title:
-      - '/^build\([^)]+\):/i'
+      - '/^build\\([^)]+\\):/i'
   - label: "dependencies"
     title:
       - "/^build\\(deps\\):/i"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,75 +3,123 @@ tag-template: "$RESOLVED_VERSION"
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 sort-direction: ascending
 categories:
+  # 1. Version Resolver Categories (New Schema)
+  - type: "version-resolver"
+    when:
+      labels:
+        - "breaking-change"
+    semver-increment: "major"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "feature"
+        - "enhancement"
+    semver-increment: "minor"
+
+  - type: "version-resolver"
+    when:
+      labels:
+        - "bug"
+        - "fix"
+        - "bugfix"
+        - "performance"
+        - "refactor"
+        - "style"
+        - "build"
+        - "chore"
+        - "documentation"
+        - "CI"
+        - "test"
+        - "code-quality"
+        - "revert"
+    semver-increment: "patch"
+
+  - type: "version-resolver"
+    semver-increment: "patch" # Default fallback
+
+  # 2. Changelog Grouping Categories (Updated 'when' syntax)
   - title: "💥 Breaking Change 💥"
-    labels:
-      - "breaking-change"
+    when:
+      labels:
+        - "breaking-change"
+
   - title: "✨ New Features ✨"
-    labels:
-      - "enhancement"
-      - "feature"
+    when:
+      labels:
+        - "enhancement"
+        - "feature"
+
   - title: "🐛 Bug Fixes 🐛"
-    labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
+    when:
+      labels:
+        - "fix"
+        - "bugfix"
+        - "bug"
+
   - title: "⚡ Performance ⚡"
-    labels:
-      - "performance"
+    when:
+      labels:
+        - "performance"
+
   - title: "🔧 Maintenance 🔧"
-    labels:
-      - "chore"
-      - "documentation"
-      - "maintenance"
-      - "repo"
-      - "dependencies"
-      - "github_actions"
-      - "refactor"
-      - "style"
-      - "build"
-      - "revert"
-      - "translations"
+    when:
+      labels:
+        - "chore"
+        - "documentation"
+        - "maintenance"
+        - "repo"
+        - "dependencies"
+        - "github_actions"
+        - "style"
+        - "build"
+        - "revert"
+        - "translations"
     collapse-after: 1
+
   - title: "🎓 Code Quality 🎓"
-    labels:
-      - "code-quality"
+    when:
+      labels:
+        - "code-quality"
+        - "refactor"
+
 autolabeler:
   - label: "breaking-change"
     title:
-      - '/^[a-z]+(\([^)]+\))?!:/i'
+      - '/^[a-z]+(\\([^)]+\\))?!:/i'
   - label: "feature"
     title:
-      - '/^feat(\([^)]+\))?:/i'
+      - '/^feat(\\([^)]+\\))?:/i'
   - label: "bugfix"
     title:
-      - '/^fix(\([^)]+\))?:/i'
+      - '/^fix(\\([^)]+\\))?:/i'
   - label: "refactor"
     title:
-      - '/^refactor(\([^)]+\))?:/i'
+      - '/^refactor(\\([^)]+\\))?:/i'
   - label: "code-quality"
     title:
-      - '/^test(\([^)]+\))?:/i'
+      - '/^test(\\([^)]+\\))?:/i'
   - label: "CI"
     title:
-      - '/^ci(\([^)]+\))?:/i'
+      - '/^ci(\\([^)]+\\))?:/i'
   - label: "chore"
     title:
-      - '/^chore(\([^)]+\))?:/i'
+      - '/^chore(\\([^)]+\\))?:/i'
   - label: "documentation"
     title:
-      - '/^docs(\([^)]+\))?:/i'
+      - '/^docs(\\([^)]+\\))?:/i'
   - label: "style"
     title:
-      - '/^style(\([^)]+\))?:/i'
+      - '/^style(\\([^)]+\\))?:/i'
   - label: "performance"
     title:
-      - '/^perf(\([^)]+\))?:/i'
+      - '/^perf(\\([^)]+\\\):/i'
   - label: "revert"
     title:
-      - '/^revert(\([^)]+\))?:/i'
+      - '/^revert(\\([^)]+\\))?:/i'
   - label: "build"
     title:
-      - '/^build(\([^)]+\))?:/i'
+      - '/^build(\\([^)]+\\))?:/i'
   - label: "dependencies"
     title:
       - "/^build\\(deps\\):/i"
@@ -82,30 +130,7 @@ autolabeler:
   - label: "translations"
     files:
       - "custom_components/openevse/translations/**/*"
-version-resolver:
-  major:
-    labels:
-      - "breaking-change"
-  minor:
-    labels:
-      - "feature"
-      - "enhancement"
-  patch:
-    labels:
-      - "bug"
-      - "fix"
-      - "bugfix"
-      - "performance"
-      - "refactor"
-      - "style"
-      - "build"
-      - "chore"
-      - "documentation"
-      - "CI"
-      - "test"
-      - "code-quality"
-      - "revert"
-  default: patch
+
 template: |
   [![Downloads for this release](https://img.shields.io/github/downloads/firstof9/openevse/$RESOLVED_VERSION/total.svg)](https://github.com/firstof9/openevse/releases/$RESOLVED_VERSION)
 

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -31,4 +31,4 @@ jobs:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+      - uses: release-drafter/release-drafter@ed4bc48ec97379be2258e7b7ac2624a3e26ab809 # v7.4.0


### PR DESCRIPTION
This PR updates the `.github/release-drafter.yml` configuration to comply with the new schema introduced in Release Drafter PR #1558.

Key changes:
- Unified the category configuration schema (using `type: "version-resolver"` and `when: labels/label`).
- Migrated top-level `include/exclude` and `version-resolver` settings into the new `categories` model.
- Updated changelog grouping syntax.

This ensures consistent change classification and version resolution across the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated release categorization and version selection across major, minor, and patch updates.
  - Refined change-labeling rules to support more consistent classification of improvements, fixes, and breaking changes.
  - Updated changelog grouping to produce clearer, more predictable release notes.
  - Enhanced recognition of scoped change titles for more reliable automated processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->