### PR TITLE
feat: add RFID access control switch entity

### DIFF
--- a/custom_components/openevse/__init__.py
+++ b/custom_components/openevse/__init__.py
@@ -67,6 +67,7 @@ from .const import (
     SELECT_TYPES,
     SENSOR_FIELDS,
     SENSOR_TYPES,
+    SWITCH_TYPES,
     UNSUB_LISTENERS,
     VERSION,
 )
@@ -814,6 +815,7 @@ class OpenEVSEUpdateCoordinator(DataUpdateCoordinator):
         data.update(self._collect_values(SELECT_TYPES, "select"))
         data.update(self._collect_values(NUMBER_TYPES, "number"))
         data.update(self._collect_values(LIGHT_TYPES, "light"))
+        data.update(self._collect_values(SWITCH_TYPES, "switch"))
         if "vehicle_range" in data and isinstance(data["vehicle_range"], tuple):
             data["vehicle_range"] = data["vehicle_range"][0]
         self.logger.debug("Parsed data: %s", data)

--- a/custom_components/openevse/const.py
+++ b/custom_components/openevse/const.py
@@ -529,6 +529,15 @@ SWITCH_TYPES: Final[tuple[OpenEVSESwitchEntityDescription, ...]] = (
         device_class=SwitchDeviceClass.SWITCH,
         value_fn=lambda data: data.get("mqtt_vehicle_range_miles"),
     ),
+    OpenEVSESwitchEntityDescription(
+        name="RFID Access",
+        key="rfid_enabled",
+        toggle_command="set_rfid_enabled",
+        device_class=SwitchDeviceClass.SWITCH,
+        entity_category=EntityCategory.CONFIG,
+        min_version="4.1.4",
+        value_fn=lambda data: data.get("rfid_enabled"),
+    ),
 )
 
 # Name, options, command, entity category

--- a/custom_components/openevse/manifest.json
+++ b/custom_components/openevse/manifest.json
@@ -16,7 +16,7 @@
     "openevsehttp"
   ],
   "requirements": [
-    "python-openevse-http==1.5.0"
+    "python-openevse-http==1.6.0"
   ],
   "version": "0.0.0-dev",
   "zeroconf": [

--- a/custom_components/openevse/select.py
+++ b/custom_components/openevse/select.py
@@ -10,6 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from openevsehttp.exceptions import CommandFailedError as OpenEVSECommandFailedError
 
 from . import (
     CONNECTION_ERRORS,
@@ -104,7 +105,7 @@ class OpenEVSESelect(CoordinatorEntity, OpenEVSEEntity, SelectEntity):
                         self.coordinator.logger.debug(
                             "Select Auto response: %s", response
                         )
-                    except RuntimeError as err:
+                    except (RuntimeError, OpenEVSECommandFailedError) as err:
                         if "Failed to release manual override" in str(err):
                             self.coordinator.logger.debug(
                                 "No active override to clear."

--- a/custom_components/openevse/services.py
+++ b/custom_components/openevse/services.py
@@ -14,6 +14,7 @@ from homeassistant.core import (
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from openevsehttp.exceptions import CommandFailedError
 
 from .const import (
     ATTR_AUTO_RELEASE,
@@ -277,7 +278,7 @@ class OpenEVSEServices:
                     logger.debug("Override clear command sent.")
                 except CONNECTION_ERRORS as err:
                     logger.error(CONNECTION_ERROR, err)
-                except RuntimeError as err:
+                except (RuntimeError, CommandFailedError) as err:
                     if "Failed to release manual override" in str(err):
                         logger.debug("No active override to clear.")
                     else:

--- a/custom_components/openevse/switch.py
+++ b/custom_components/openevse/switch.py
@@ -115,6 +115,8 @@ class OpenEVSESwitch(CoordinatorEntity, OpenEVSEEntity, SwitchEntity):
                 await self._manager.set_shaper(True)
             elif self.toggle_command == "set_mqtt_vehicle_range_miles":
                 await self._manager.set_mqtt_vehicle_range_miles(True)
+            elif self.toggle_command == "set_rfid_enabled":
+                await self._manager.set_rfid_enabled(True)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:
@@ -135,6 +137,8 @@ class OpenEVSESwitch(CoordinatorEntity, OpenEVSEEntity, SwitchEntity):
                 await self._manager.set_shaper(False)
             elif self.toggle_command == "set_mqtt_vehicle_range_miles":
                 await self._manager.set_mqtt_vehicle_range_miles(False)
+            elif self.toggle_command == "set_rfid_enabled":
+                await self._manager.set_rfid_enabled(False)
             else:
                 await getattr(self._manager, self.toggle_command)()
         except CONNECTION_ERRORS as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-openevse-http==1.5.0
+python-openevse-http==1.6.0

--- a/tests/const.py
+++ b/tests/const.py
@@ -47,6 +47,7 @@ CHARGER_DATA = {
     "using_ethernet": False,
     "shaper_active": False,
     "mqtt_vehicle_range_miles": False,
+    "rfid_enabled": False,
     "max_current_soft": 48,
     "led_brightness": 128,
 }
@@ -114,6 +115,7 @@ DIAG_DEVICE_RESULTS = {
     "ota_update": False,
     "override_state": "auto",
     "protocol_version": None,
+    "rfid_enabled": False,
     "rtc_temperature": 50.3,
     "service_level": "2",
     "shaper_active": True,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,7 +65,7 @@ async def test_setup_entry(hass, test_charger, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -86,7 +86,7 @@ async def test_setup_entry_bad_serial(hass, test_charger_bad_serial, mock_ws_sta
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -138,7 +138,7 @@ async def test_setup_entry_state_change(hass, test_charger, mock_ws_start, caplo
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -201,7 +201,7 @@ async def test_setup_entry_state_change_timeout(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 24
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -233,7 +233,7 @@ async def test_setup_entry_state_change_2(hass, test_charger, mock_ws_start, cap
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -270,7 +270,7 @@ async def test_setup_entry_state_change_2_bad_post(
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 25
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
@@ -336,7 +336,7 @@ async def test_setup_entry_v2(hass, test_charger_v2, mock_ws_start):
 
     assert len(hass.states.async_entity_ids(BINARY_SENSOR_DOMAIN)) == 4
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 23
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 5
     assert len(hass.states.async_entity_ids(SELECT_DOMAIN)) == 2
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -51,7 +51,7 @@ async def test_switches(
     await hass.async_block_till_done()
 
     # Ensure all switches are created
-    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 7
 
     # Get the coordinator to simulate data updates
     coordinator = hass.data[DOMAIN][entry.entry_id][COORDINATOR]
@@ -229,6 +229,49 @@ async def test_switches(
     state = hass.states.get(entity_id)
     assert state.state == "off"
 
+    # -------------------------------------------------------------------------
+    # 6. Test RFID Access Switch
+    # -------------------------------------------------------------------------
+    # Initial State: In CHARGER_DATA, "rfid_enabled" is False, so switch is OFF.
+    entity_id = "switch.openevse_rfid_access"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "off"
+
+    # Action: Turn On
+    mock_aioclient.post(
+        "http://openevse.test.tld/config",
+        status=200,
+        text='{"msg": "OK"}',
+    )
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_on", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["rfid_enabled"] = True
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be ON
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+
+    # Action: Turn Off
+    await hass.services.async_call(
+        SWITCH_DOMAIN, "turn_off", {"entity_id": entity_id}, blocking=True
+    )
+
+    # Simulate update
+    coordinator._data["rfid_enabled"] = False
+    coordinator.async_set_updated_data(coordinator._data)
+    await hass.async_block_till_done()
+
+    # Assert: Entity should now be OFF
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+
 
 async def test_switches_v2(
     hass,
@@ -264,13 +307,18 @@ async def test_switches_v2(
         await hass.config_entries.async_forward_entry_setups(entry, [SWITCH_DOMAIN])
         await hass.async_block_till_done()
 
-        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 6
+        assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 7
         entries = hass.config_entries.async_entries(DOMAIN)
         assert len(entries) == 1
 
         assert DOMAIN in hass.config.components
 
         entity_id = "switch.openevse_solar_pv_divert"
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.state == "unavailable"
+
+        entity_id = "switch.openevse_rfid_access"
         state = hass.states.get(entity_id)
         assert state
         assert state.state == "unavailable"


### PR DESCRIPTION
## Description

Adds support for an RFID access control switch entity (`switch.openevse_rfid_access`) using the `rfid_enabled` property and `set_rfid_enabled` command introduced in `python-openevse-http` 1.6.0. Also updates error handling for `clear_override` to support upstream `CommandFailedError`.

Fixes #724

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
